### PR TITLE
Remove this library from its own blueprint.

### DIFF
--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -5,7 +5,6 @@ module.exports = {
   normalizeEntityName: function(){},
   afterInstall: function() {
     return Promise.all([
-      this.addPackageToProject('ember-cli-blueprint-test-helpers', '^0.5.0'),
       this.addPackageToProject('ember-cli-internal-test-helpers', '^0.5.0'),
       this.addPackageToProject('glob', '5.0.13'),
       this.addPackageToProject('mocha', '^2.2.1'),


### PR DESCRIPTION
Running `ember install ember-cli-blueprint-test-helpers` already installs the test helpers, no need to do it again.