### PR TITLE
Remove extra references to `nodetest.js`.

### DIFF
--- a/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
@@ -14,7 +14,7 @@ rimraf.sync('.node_modules-tmp');
 rimraf.sync('.bower_components-tmp');
 
 var root = 'node-tests/{blueprints,acceptance,unit}';
-var _checkOnlyInTests = Promise.denodeify(mochaOnlyDetector.checkFolder.bind(null, root + '/**/*{-nodetest}.js'));
+var _checkOnlyInTests = Promise.denodeify(mochaOnlyDetector.checkFolder.bind(null, root + '/**/*{-test}.js'));
 var optionOrFile = process.argv[2];
 var mocha = new Mocha({
   timeout: 5000,
@@ -29,7 +29,7 @@ testFiles = jshint.concat(testFiles);
 if (optionOrFile === 'all') {
   addFiles(mocha, testFiles);
   addFiles(mocha, 'node-tests/**/*-test.js');
-  addFiles(mocha, '/**/*-nodetest-slow.js');
+  addFiles(mocha, '/**/*-test-slow.js');
 } else if (process.argv.length > 2)  {
   addFiles(mocha, process.argv.slice(2));
 } else {


### PR DESCRIPTION
The main references were moved to `node-tests/` folder with a file ending in `-test.js` (not `-nodetest.js`).  These look like left-overs.

@trabus - Can you confirm?