### PR TITLE
Remove double `node-tests` prefix.

### DIFF
--- a/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
@@ -20,7 +20,7 @@ var mocha = new Mocha({
   timeout: 5000,
   reporter: 'spec'
 });
-var testFiles = glob.sync(root + 'node-tests/**/*-test.js');
+var testFiles = glob.sync(root + '/**/*-test.js');
 /*var jshintPosition = testFiles.indexOf('tests/unit/jshint-test.js');
 var jshint = testFiles.splice(jshintPosition, 1);
 


### PR DESCRIPTION
Since `root` already includes `node-tests`, this was actually looking for files in `node-tests/node-tests/**/*-test.js`.