### PR TITLE
fixed path to fixtures

### DIFF
--- a/lib/helpers/blueprint-helper.js
+++ b/lib/helpers/blueprint-helper.js
@@ -194,8 +194,8 @@ function assertThrows(assertion, err) {
 
 function getPackage(pathRoot, type) {
   // console.log('pathRoot:',pathRoot, type);
-  // console.log(path.resolve(pathRoot, 'tests', 'fixtures', type, 'package'));
-  return path.resolve(pathRoot, 'tests', 'fixtures', type, 'package');
+  // console.log(path.resolve(pathRoot, 'node-tests', 'fixtures', type, 'package'));
+  return path.resolve(pathRoot, 'node-tests', 'fixtures', type, 'package');
 }
 
 function getProjectRoot(pathRoot) {

--- a/lib/helpers/project-init.js
+++ b/lib/helpers/project-init.js
@@ -33,7 +33,7 @@ module.exports = function(options) {
   var presets = initPresets[target]();
   var projectName = (target === 'addon') ? 'my-addon' : 'my-app';
   var cliOptions = {
-    package: options.package || path.resolve(process.cwd(), '..', '..', 'tests', 'fixtures', type, 'package'),
+    package: options.package || path.resolve(process.cwd(), '..', '..', 'node-tests', 'fixtures', type, 'package'),
     type: type,
     disableDependencyChecker: true
   };


### PR DESCRIPTION
Path to fixtures was still pointing to `tests` instead of `node-tests`.