### PR TITLE
Bump version of dependency in blueprint

### DIFF
--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -5,7 +5,7 @@ module.exports = {
   normalizeEntityName: function(){},
   afterInstall: function() {
     return Promise.all([
-      this.addPackageToProject('ember-cli-internal-test-helpers', '^0.5.0'),
+      this.addPackageToProject('ember-cli-internal-test-helpers', '^0.6.0'),
       this.addPackageToProject('glob', '5.0.13'),
       this.addPackageToProject('mocha', '^2.2.1'),
       this.addPackageToProject('mocha-only-detector', '0.0.2'),


### PR DESCRIPTION
This updates the used version of `ember-cli-internal-test-helpers` to the recently released `0.6.0`. This is based on the work done in  1fefa40fa845871a2ad251b0940b89ab2b7a2b25.