### PR TITLE
Blueprint fixes

### DIFF
--- a/blueprints/ember-cli-blueprint-test-helpers/files/.npmignore
+++ b/blueprints/ember-cli-blueprint-test-helpers/files/.npmignore
@@ -1,1 +1,0 @@
-node-tests/

--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -5,11 +5,12 @@ module.exports = {
   normalizeEntityName: function(){},
   afterInstall: function() {
     return Promise.all([
+      this.insertIntoFile('./.npmignore', 'node-tests/'),
       this.addPackageToProject('ember-cli-internal-test-helpers', '^0.6.0'),
-      this.addPackageToProject('glob', '5.0.13'),
-      this.addPackageToProject('mocha', '^2.2.1'),
-      this.addPackageToProject('mocha-only-detector', '0.0.2'),
-      this.addPackageToProject('rimraf', '2.3.2')
+      // this.addPackageToProject('glob', '5.0.13'),
+      // this.addPackageToProject('mocha', '^2.2.1'),
+      // this.addPackageToProject('mocha-only-detector', '0.0.2'),
+      // this.addPackageToProject('rimraf', '2.3.2')
     ]);
   }
 };

--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -6,11 +6,10 @@ module.exports = {
   afterInstall: function() {
     return Promise.all([
       this.insertIntoFile('./.npmignore', 'node-tests/'),
-      this.addPackageToProject('ember-cli-internal-test-helpers', '^0.6.0'),
-      // this.addPackageToProject('glob', '5.0.13'),
-      // this.addPackageToProject('mocha', '^2.2.1'),
-      // this.addPackageToProject('mocha-only-detector', '0.0.2'),
-      // this.addPackageToProject('rimraf', '2.3.2')
+      this.addPackageToProject('ember-cli-internal-test-helpers', '^0.7.0'),
+      this.addPackageToProject('glob', '5.0.13'),
+      this.addPackageToProject('mocha-only-detector', '0.0.2'),
+      this.addPackageToProject('rimraf', '^2.4.3'),
     ]);
   }
 };

--- a/lib/helpers/blueprint-helper.js
+++ b/lib/helpers/blueprint-helper.js
@@ -195,7 +195,7 @@ function assertThrows(assertion, err) {
 function getPackage(pathRoot, type) {
   // console.log('pathRoot:',pathRoot, type);
   // console.log(path.resolve(pathRoot, 'tests', 'fixtures', type, 'package'));
-  return path.resolve(pathRoot, 'tests', 'fixtures', type, 'package');
+  return path.resolve(pathRoot, 'node-tests', 'fixtures', type, 'package');
 }
 
 function getProjectRoot(pathRoot) {

--- a/lib/helpers/project-init.js
+++ b/lib/helpers/project-init.js
@@ -33,7 +33,7 @@ module.exports = function(options) {
   var presets = initPresets[target]();
   var projectName = (target === 'addon') ? 'my-addon' : 'my-app';
   var cliOptions = {
-    package: options.package || path.resolve(process.cwd(), '..', '..', 'tests', 'fixtures', type, 'package'),
+    package: options.package || path.resolve(process.cwd(), '..', '..', 'node-tests', 'fixtures', type, 'package'),
     type: type,
     disableDependencyChecker: true
   };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
     "debug": "^2.2.0",
-    "ember-cli-internal-test-helpers": "^0.6.0",
+    "ember-cli-internal-test-helpers": "^0.7.0",
     "exists-sync": "0.0.3",
     "findup": "^0.1.5",
     "fs-extra": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "walk-sync": "^0.2.5"
   },
   "devDependencies": {
-    "ember-cli": "^1.13.8",
+    "ember-cli": "^2.3.0-beta.2",
     "mocha-only-detector": "0.0.2",
     "rimraf": "^2.4.3"
   }


### PR DESCRIPTION
Removed unnecessary installs for default blueprint, and updating `.npmignore` through `insertIntoFile` (fixing #3).

Also bumped ember-cli to 2.3.0-beta.2