### PR TITLE
remove unneccessary lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "exists-sync": "0.0.3",
     "findup": "^0.1.5",
     "fs-extra": "^0.24.0",
-    "lodash": "^3.6.0",
     "tmp-sync": "^1.0.0",
     "walk-sync": "^0.2.5"
   },


### PR DESCRIPTION
seems to be no longer needed with extraction of helpers into ember-cli-internal-test-helpers

https://github.com/ember-cli/ember-cli-blueprint-test-helpers/commit/899ec6a6c68ee4b9c27b6c9061ea682c535cf66a#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

also I was having difficult running the tests with the instructions on the README of ``` node tests/nodetest-runner.js ```