### PR TITLE
Add "testFramework" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The options should contain a files object, as well as any of the following optio
 * __usePods__ _(boolean)_: Sets up `.ember-cli` file with `"usePods": true`. Default: false
 * __podModulePrefix__ _(boolean)_: Sets up `config/environment.js` with 'app/pods' as the `podModulePrefix`. Default: false
 * __target__ _(string)_: Defines the type of project to setup for the test. Recognized values: __'app'__, __'addon'__, __'inRepoAddon'__
+* __testFramework__ _(string)_: Defines the type of test framework to use for the project. Recognized values: __'qunit'__ (default), __'mocha'__. This will cause the `package.json` file to contain either `ember-cli-qunit` or `ember-cli-mocha`.
 * __files__ _(array)_: Array of files to assert, represented by objects with `file`, `exists`, `contains`, or `doesNotContain` properties. Example object: `{file: 'path-to-file', contains: ['file contents to compare'], doesNotContain: ['file contents that shouldn\'t be present'], exists: true}`
 * __throws__ _(regexp / / or object)_: Expected error message or excerpt to assert. Optionally, can be an object containing a `message` and `type` property. The `type` is a string of the error name. Example RegExp: `/Expected error message text./` Example object: `{message: /Expected message/, type: 'SilentError'}`
 * __beforeGenerate__ _(function)_: Hook to execute before generating blueprint. Can be used for additional setup and assertions.

--- a/lib/helpers/project-setup.js
+++ b/lib/helpers/project-setup.js
@@ -41,12 +41,24 @@ function setupPodConfig(options) {
   @return {Promise}
 */
 function setupPackage(options) {
-  if (options && options.packageName) {
+  if (options && (options.packageName || options.testFramework)) {
     // console.log('packageName',options.packageName)
     var packagePath = path.join(process.cwd(),'package.json');
     var contents  = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
     // console.log(packagePath);
-    contents.devDependencies[options.packageName] = '*';
+    if (options.packageName) {
+      contents.devDependencies[options.packageName] = '*';
+    }
+
+    if (!options.testFramework || options.testFramework === 'qunit') {
+      // noop
+    } else if (options.testFramework === 'mocha') {
+      delete contents.devDependencies['ember-cli-qunit'];
+      contents.devDependencies['ember-cli-mocha'] = '*';
+    } else {
+      return Promise.reject(new Error('Unknown "testFramework" specified.'));
+    }
+
     // console.log(contents)
     fs.writeFileSync(path.join(process.cwd(), 'package.json'), JSON.stringify(contents, null, 2));
   }


### PR DESCRIPTION
This PR adds a `testFramework` option that can be used to add either `ember-cli-qunit` or `ember-cli-mocha` to the `package.json`  file of the project that is being tested.

see https://github.com/emberjs/data/compare/master...Turbo87:mocha-blueprint-tests for an example of how to use this

resolves #27 