### PR TITLE
Add "packages" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ The options should contain a files object, as well as any of the following optio
 * __usePods__ _(boolean)_: Sets up `.ember-cli` file with `"usePods": true`. Default: false
 * __podModulePrefix__ _(boolean)_: Sets up `config/environment.js` with 'app/pods' as the `podModulePrefix`. Default: false
 * __target__ _(string)_: Defines the type of project to setup for the test. Recognized values: __'app'__, __'addon'__, __'inRepoAddon'__
+* __packages__ _(array)_: A list of packages that should be removed from or added to the `package.json` file after the project has been set up (only affects the test this option is set for). Example:
+  
+  ```js
+  packages: [
+    { name: 'ember-cli-qunit', delete: true },
+    { name: 'ember-cli-mocha', dev: true, version: '~1.0.2' }
+  ]
+  ```
 * __files__ _(array)_: Array of files to assert, represented by objects with `file`, `exists`, `contains`, or `doesNotContain` properties. Example object: `{file: 'path-to-file', contains: ['file contents to compare'], doesNotContain: ['file contents that shouldn\'t be present'], exists: true}`
 * __throws__ _(regexp / / or object)_: Expected error message or excerpt to assert. Optionally, can be an object containing a `message` and `type` property. The `type` is a string of the error name. Example RegExp: `/Expected error message text./` Example object: `{message: /Expected message/, type: 'SilentError'}`
 * __beforeGenerate__ _(function)_: Hook to execute before generating blueprint. Can be used for additional setup and assertions.

--- a/lib/helpers/project-setup.js
+++ b/lib/helpers/project-setup.js
@@ -37,16 +37,33 @@ function setupPodConfig(options) {
   @method setupPackage
   @param {Object} [options]
   @param {String} [options.packageName]
-  @param {Path} [options.packagePath]
+  @param {Array} [options.packages]
   @return {Promise}
 */
 function setupPackage(options) {
-  if (options && options.packageName) {
+  if (options && (options.packageName || options.packages)) {
     // console.log('packageName',options.packageName)
     var packagePath = path.join(process.cwd(),'package.json');
     var contents  = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
     // console.log(packagePath);
-    contents.devDependencies[options.packageName] = '*';
+    if (options.packageName) {
+      contents.devDependencies[options.packageName] = '*';
+    }
+
+    if (options.packages) {
+      contents.dependencies = contents.dependencies || {};
+
+      options.packages.forEach(function(pkg) {
+        if (pkg.delete) {
+          delete contents.dependencies[pkg.name];
+          delete contents.devDependencies[pkg.name];
+        } else {
+          var dependencies = pkg.dev ? contents.devDependencies : contents.dependencies;
+          dependencies[pkg.name] = pkg.version || '*';
+        }
+      });
+    }
+
     // console.log(contents)
     fs.writeFileSync(path.join(process.cwd(), 'package.json'), JSON.stringify(contents, null, 2));
   }


### PR DESCRIPTION
This PR implements the idea expressed in https://github.com/ember-cli/ember-cli-blueprint-test-helpers/pull/28#issuecomment-188356411 and resolves https://github.com/ember-cli/ember-cli-blueprint-test-helpers/issues/27.

Essentially this feature is needed to be able to test mocha blueprints in e.g. `ember-data`

/cc @trabus @rwjblue 