### PR TITLE
Fixes #34 fix assertThrows by using chai-as-promised rejectedWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,36 +73,47 @@ The options should contain a files object, as well as any of the following optio
 
 * __target__ _(string)_: Defines the type of project to setup for the test. Recognized values: __'app'__, __'addon'__, __'inRepoAddon'__
 * __packages__ _(array)_: A list of packages that should be removed from or added to the `package.json` file after the project has been set up (only affects the test this option is set for). Example:
-  
+
   ```js
   packages: [
     { name: 'ember-cli-qunit', delete: true },
     { name: 'ember-cli-mocha', dev: true, version: '~1.0.2' }
   ]
   ```
-* __files__ _(array)_: Array of files to assert, represented by objects with `file`, `exists`, `contains`, or `doesNotContain` properties. 
-Example object: 
+* __files__ _(array)_: Array of files to assert, represented by objects with `file`, `exists`, `contains`, or `doesNotContain` properties.
+Example object:
 
   ```js
   files: [
     {
-      file: 'path-to-file.js', 
-      contains: ['file contents to compare'], 
-      doesNotContain: ['file contents that shouldn\'t be present'], 
+      file: 'path-to-file.js',
+      contains: ['file contents to compare'],
+      doesNotContain: ['file contents that shouldn\'t be present'],
       exists: true //default true
     }
   ]
   ```
-* __throws__ _(regexp / / or object)_: Expected error message or excerpt to assert. Optionally, can be an object containing a `message` and `type` property. The `type` is a string of the error name. Example RegExp: 
+* __throws__ _(string / / regexp / / or object)_: Expected error message or excerpt to assert. Optionally, can be an object containing a `message` and `type` property. The `type` is a string of the error name.
+Example String:
 
   ```js
-  /Expected error message text./
-  ``` 
-Example object: 
+  throws: 'Expected error message text.'
+  ```
+Example RegExp:
 
   ```js
-  {
-    message: /Expected message/, 
+  throws: /Expected error message text./
+  ```
+Example object:
+
+  ```js
+  throws: {
+    message: 'Expected message', 
+    type: 'SilentError'
+  }
+  // or
+  throws: {
+    message: /Expected message/,
     type: 'SilentError'
   }
   ```
@@ -154,7 +165,7 @@ You can also pass an object containing the message and error type.
 ```js
 it('adapter application cannot extend from --base-class=application', function() {
   return generateAndDestroy(['adapter', 'application', '--base-class=application'], {
-    throws: { 
+    throws: {
       message: /Adapters cannot extend from themself/,
       type: 'SilentError'
     }

--- a/lib/helpers/blueprint-helper.js
+++ b/lib/helpers/blueprint-helper.js
@@ -28,12 +28,9 @@ function generate(args, options) {
   var command = processCommand('generate', args, options)
     .then(assertGenerated.bind(null, fileAssertions));
 
-  if(options.throws) {
-    command.catch(assertThrows.bind(null, options.throws));
-  } else {
-    command.catch(function(err) { throw err;});
+  if (options.throws) {
+    return assertThrows(command, options, options.throws);
   }
-
   return command;
 }
 
@@ -52,9 +49,7 @@ function destroy(args, options) {
     .then(assertDestroyed.bind(null, fileAssertions));
 
   if (options.throws) {
-    command.catch(assertThrows.bind(null, options.throws));
-  } else {
-    command.catch(function(err) { throw err;});
+    return assertThrows(command, options, options.throws);
   }
   return command;
 }
@@ -82,10 +77,8 @@ function generateAndDestroy(args, options) {
     })
     .then(assertDestroyed.bind(null, fileAssertions));
 
-  if(options.throws) {
-    command.catch(assertThrows.bind(null, options.throws));
-  } else {
-    command.catch(function(err) { throw err;});
+  if (options.throws) {
+    return assertThrows(command, options, options.throws);
   }
   return command;
 }
@@ -140,7 +133,7 @@ function processCommand(command, args, options) {
     .then(function() {
       return ember(commandArgs, cliOptions);
     })
-    .then(resultContents.bind(null, options, tmpenv))
+    .then(resultContents.bind(null, options, tmpenv), throwResult.bind(null, options))
     .then(afterProcess)
     .then(teardownProject.bind(null, options))
     .catch(function(err) {
@@ -177,6 +170,29 @@ function resultContents(options, env, result) {
     outputFiles: env && env.tmpdir && walkSync(env.tmpdir) || null
   };
 }
+
+/**
+  Rejection handler to extract error from results object and rethrow
+  Also asserts the result error type before rethrow
+  @function throwResult
+  @param {Object} [options]
+  @param {Object|String|RegExp} [options.throws]
+  @param {Object} [err] result received by reject promise
+  @throws {Error}
+*/
+function throwResult(options, err) {
+  if (options && options.throws && err && err.statusCode) {
+    if (err.errorLog && err.errorLog.length) {
+      // assert the error type if we've defined one to check
+      if (options.throws.type) {
+        expect(err.errorLog[0].name).to.equal(options.throws.type);
+      }
+      throw err.errorLog[0];
+    }
+  }
+  throw err;
+}
+
 /**
   Process assertions from hook
   @function processAssertions
@@ -220,22 +236,25 @@ function assertDestroyed(files) {
 /**
   Assert specific error is thrown.
   @function assertThrows
+  @param {Promise} [promise] promise to assert
   @param {RegExp|Object} [assertion] message or error to match
   @param {Object} [err] error to assert
   @return {Chai.Assertion}
 */
-function assertThrows(assertion, err) {
+function assertThrows(promise, options, assertion) {
   var message;
   if (assertion instanceof RegExp) {
     message = assertion;
-  } else if (assertion.message){
-    message = assertion.message;
+  } else if (assertion.message) {
+    if (assertion.message instanceof RegExp){
+      message = assertion.message;
+    } else {
+      message = new RegExp(assertion.message);
+    }
+  } else {
+    message = new RegExp(assertion);
   }
-  expect(err.message).to.match(message);
-
-  if (assertion.name) {
-    expect(err.name).to.match(assertion.name);
-  }
+  return expect(promise).to.be.rejectedWith(message);
 }
 /**
   Get package from fixtures of type defined


### PR DESCRIPTION
The previous method for asserting thrown errors was flawed, instead switching to use chai-as-promised's `rejectedWith` method.

Also adapted throws option to accept strings, so all of the following are acceptable.
Example String:
  ```js
  throws: 'Expected error message text.'
  ```
Example RegExp:
  ```js
  throws: /Expected error message text./
  ```
Example object:
  ```js
  throws: {
    message: 'Expected message', 
    type: 'SilentError'
  }
  // or
  throws: {
    message: /Expected message/,
    type: 'SilentError'
  }
  ```