### PR TITLE
Remove EOLNEWLINE condition

### DIFF
--- a/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
@@ -6,10 +6,6 @@ var RSVP = require('RSVP');
 var rimraf = require('rimraf');
 var mochaOnlyDetector = require('mocha-only-detector');
 
-if (process.env.EOLNEWLINE) {
-  require('os').EOL = '\n';
-}
-
 rimraf.sync('.node_modules-tmp');
 rimraf.sync('.bower_components-tmp');
 


### PR DESCRIPTION
As discussed in `ember-cli` `\n` should be used everywhere instead of native line breaks