### PR TITLE
Added rsvp as dep for nodetest-runner to replace ember-cli/lib/ext/promise

### DIFF
--- a/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
@@ -2,7 +2,7 @@
 
 var glob = require('glob');
 var Mocha = require('mocha');
-var Promise = require('rsvp');
+var RSVP = require('RSVP');
 var rimraf = require('rimraf');
 var mochaOnlyDetector = require('mocha-only-detector');
 
@@ -14,7 +14,7 @@ rimraf.sync('.node_modules-tmp');
 rimraf.sync('.bower_components-tmp');
 
 var root = 'node-tests/{blueprints,acceptance,unit}';
-var _checkOnlyInTests = Promise.denodeify(mochaOnlyDetector.checkFolder.bind(null, root + '/**/*{-test}.js'));
+var _checkOnlyInTests = RSVP.denodeify(mochaOnlyDetector.checkFolder.bind(null, root + '/**/*{-test}.js'));
 var optionOrFile = process.argv[2];
 var mocha = new Mocha({
   timeout: 5000,
@@ -60,7 +60,7 @@ function ciVerificationStep() {
   if (process.env.CI === 'true') {
     return checkOnlyInTests();
   } else {
-    return Promise.resolve();
+    return RSVP.Promise.resolve();
   }
 }
 

--- a/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
@@ -2,7 +2,7 @@
 
 var glob = require('glob');
 var Mocha = require('mocha');
-var Promise = require('ember-cli/lib/ext/promise');
+var Promise = require('rsvp');
 var rimraf = require('rimraf');
 var mochaOnlyDetector = require('mocha-only-detector');
 

--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -11,6 +11,7 @@ module.exports = {
       this.addPackageToProject('mocha', '^2.2.1'),
       this.addPackageToProject('mocha-only-detector', '0.0.2'),
       this.addPackageToProject('rimraf', '^2.4.3'),
+      this.addPackageToProject('rsvp','^3.0.17')
     ]);
   }
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "exists-sync": "0.0.3",
     "findup": "^0.1.5",
     "fs-extra": "^0.24.0",
+    "rsvp": "^3.0.17",
     "tmp-sync": "^1.0.0",
     "walk-sync": "^0.2.5"
   },


### PR DESCRIPTION
As per [this conversation](https://github.com/emberjs/ember.js/pull/13029#discussion_r55144069) added RSVP as a dependency of nodetest-runner, so consuming projects don't have to depend on ember-cli.