### PR TITLE
Add glob to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "exists-sync": "0.0.3",
     "findup": "^0.1.5",
     "fs-extra": "^0.24.0",
+    "glob": "5.0.13",
     "rsvp": "^3.0.17",
     "tmp-sync": "^1.0.0",
     "walk-sync": "^0.2.5"


### PR DESCRIPTION
`glob` is required to develop this addon and run the tests, but it was missing from `package.json`. This PR adds it.