### PR TITLE
Fix require() call

### DIFF
--- a/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/files/node-tests/nodetest-runner.js
@@ -2,7 +2,7 @@
 
 var glob = require('glob');
 var Mocha = require('mocha');
-var RSVP = require('RSVP');
+var RSVP = require('rsvp');
 var rimraf = require('rimraf');
 var mochaOnlyDetector = require('mocha-only-detector');
 


### PR DESCRIPTION
This should hopefully fix `Error: Cannot find module 'RSVP'` in https://travis-ci.org/emberjs/data/builds/119016376 (see https://github.com/emberjs/data/pull/4023)