### PR TITLE
A new Promise-based testing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,227 +1,238 @@
+
 ember-cli-blueprint-test-helpers
-================================
+==============================================================================
 
 [![Build Status](https://travis-ci.org/ember-cli/ember-cli-blueprint-test-helpers.svg?branch=master)](https://travis-ci.org/ember-cli/ember-cli-blueprint-test-helpers)
 [![Build status](https://ci.appveyor.com/api/projects/status/github/ember-cli/ember-cli-blueprint-test-helpers?svg=true)](https://ci.appveyor.com/project/embercli/ember-cli-blueprint-test-helpers/branch/master)
 
+test helpers for [ember-cli](https://github.com/ember-cli/ember-cli) blueprints
 
-About
------
 
-ember-cli-blueprint-test-helpers contains several test helpers for testing blueprints.
+Installation
+------------------------------------------------------------------------------
+
+Install the helpers via npm:
+
+```
+npm install --save-dev ember-cli-blueprint-test-helpers
+```
+
+Run the following command to generate the test runner:
+
+```
+ember generate ember-cli-blueprint-test-helpers
+```
+
 
 Usage
------
+------------------------------------------------------------------------------
 
-Install ember-cli-blueprint-test-helpers
+### Running Tests
 
-Running Tests
--------------
+The blueprint tests can be run by:
 
-To run the blueprint tests, run `node node-tests/nodetest-runner.js`.
-For convenience and CI purposes you can add the following to your `package.json`:
+```
+node node-tests/nodetest-runner.js
+```
+
+For convenience you should add the following to your `package.json`:
+
 ```json
 "scripts": {
   "nodetest": "node node-tests/nodetest-runner.js"
 }
 ```
-Then you can use `npm run nodetest` to run.
 
-Generating Blueprint Tests
---------------------------
+to be able to use `npm run nodetest` to run the tests.
 
-Generate a blueprint test scaffold using the blueprint-test blueprint.
-`ember g blueprint-test my-blueprint`
 
-The blueprint test will be generated inside the node-tests/blueprint folder as:
+### Generating Tests
+
+Generate a blueprint test scaffold using the `blueprint-test` generator:
+
 ```
-  node-tests/blueprints/my-blueprint-test.js
+ember generate blueprint-test my-blueprint
 ```
-The minimum common setup is in the generated test, setup for generating and destroying a blueprint in one test.
 
-Test Setup
-----------
+which will generate a test file at `node-tests/blueprints/my-blueprint-test.js`.
 
-The `setupTestHooks` convenience method sets up a blueprint test with a timeout as well as before, after, beforeEach, and afterEach hooks:
+
+### Example Usage
 
 ```js
-describe('Acceptance: ember generate', function() {
-  // pass in test instance, and an optional options object.
-  setupTestHooks(this, {timeout: 1000});
-```
-
-If you need to override or add to any of the hooks, you may pass a function in the options.
-The options supported are:
-* __timeout__ _(number)_: Duration before test times out.
-* __tmpenv__ _(tmpenv object)_: Object containing info about the temporary directory for the test. Defaults to [`lib/helpers/tmp-env.js`](https://github.com/ember-cli/ember-cli-blueprint-test-helpers/blob/master/lib/helpers/tmp-env.js)
-
-Generate and Destroy Test Helpers
----------------------------------
-
-Use `generate`, `destroy`, or `generateAndDestroy` to run a test.
-
-All three methods take the following signature:
-commandArgs (array), options (object)
-
-The commandArgs should contain any commandline properties and options that would be passed to a generate or destroy command.
-
-The options should contain a files object, as well as any of the following options:
-* __usePods__ _(boolean)_: Sets up `.ember-cli` file with `"usePods": true`. Default: false
-* __podModulePrefix__ _(boolean)_: Sets up `config/environment.js` with 'app/pods' as the `podModulePrefix`. Default: false
-* __skipInit__ _(boolean)_: Skips the temporary project init step for situations where the project has already been setup. Most commonly used when generating inside the `afterGenerate` hook.
-
-* __target__ _(string)_: Defines the type of project to setup for the test. Recognized values: __'app'__, __'addon'__, __'inRepoAddon'__
-* __packages__ _(array)_: A list of packages that should be removed from or added to the `package.json` file after the project has been set up (only affects the test this option is set for). Example:
-
-  ```js
-  packages: [
-    { name: 'ember-cli-qunit', delete: true },
-    { name: 'ember-cli-mocha', dev: true, version: '~1.0.2' }
-  ]
-  ```
-* __files__ _(array)_: Array of files to assert, represented by objects with `file`, `exists`, `contains`, or `doesNotContain` properties.
-Example object:
-
-  ```js
-  files: [
-    {
-      file: 'path-to-file.js',
-      contains: ['file contents to compare'],
-      doesNotContain: ['file contents that shouldn\'t be present'],
-      exists: true //default true
-    }
-  ]
-  ```
-* __throws__ _(string / / regexp / / or object)_: Expected error message or excerpt to assert. Optionally, can be an object containing a `message` and `type` property. The `type` is a string of the error name.
-Example String:
-
-  ```js
-  throws: 'Expected error message text.'
-  ```
-Example RegExp:
-
-  ```js
-  throws: /Expected error message text./
-  ```
-Example object:
-
-  ```js
-  throws: {
-    message: 'Expected message', 
-    type: 'SilentError'
-  }
-  // or
-  throws: {
-    message: /Expected message/,
-    type: 'SilentError'
-  }
-  ```
-* __beforeGenerate__ _(function)_: Hook to execute before generating blueprint. Can be used for additional setup and assertions.
-* __afterGenerate__ _(function)_: Hook to execute after generating blueprint. Can be used for additional setup and assertions.
-* __beforeDestroy__ _(function)_: Hook to execute before destroying blueprint. Can be used for additional setup and assertions.
-* __afterDestroy__ _(function)_: Hook to execute before destroying blueprint. Can be used for additional teardown and assertions.
-
-Example Tests
--------------
-
-The following is a basic test, asserting `my-blueprint` generated the files in the `files` array and that their content matches, and then that the blueprint was destroyed and that the files in the `files` array were properly removed.
-
-```js
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
-
-describe('Acceptance: ember generate and destroy blueprint', function() {
+describe('Acceptance: ember generate and destroy my-blueprint', function() {
+  // create and destroy temporary working directories
   setupTestHooks(this);
 
-  it('blueprint test', function() {
-    return generateAndDestroy(['my-blueprint', 'foo'], {
-      files: [
-        {
-          file: 'path/to/file.js',
-          contains: [
-            'file contents to match',
-            'more file contents\n'
-          ]
-        }
-      ]
-    });
-  });
-```
+  it('my-blueprint foo', function() {
+    var args = ['my-blueprint', 'foo'];
 
-To assert that an error is thrown when incorrect input is used, you can use the `throws` option. The throws option simply requires a regex of the full or partial error message.
+    // create a new Ember.js app in the working directory
+    return emberNew()
+      
+      // then generate and destroy the `my-blueprint` blueprint called `foo`
+      .then(() => emberGenerateDestroy(args, (file) => {
 
-```js
-it('adapter application cannot extend from --base-class=application', function() {
-  return generateAndDestroy(['adapter', 'application', '--base-class=application'], {
-    throws: /Adapters cannot extend from themself/
+        // and run some assertions in between
+        expect(file('path/to/file.js'))
+          .to.contain('file contents to match')
+          .to.contain('more file contents\n');
+      }));
+      
+     // magically done for you: assert that the generated files are destroyed again 
   });
 });
 ```
 
-You can also pass an object containing the message and error type.
+or more explicitly:
 
 ```js
-it('adapter application cannot extend from --base-class=application', function() {
-  return generateAndDestroy(['adapter', 'application', '--base-class=application'], {
-    throws: {
-      message: /Adapters cannot extend from themself/,
-      type: 'SilentError'
-    }
+describe('Acceptance: ember generate and destroy my-blueprint', function() {
+  // create and destroy temporary working directories
+  setupTestHooks(this);
+
+  it('my-blueprint foo', function() {
+    var args = ['my-blueprint', 'foo'];
+
+    // create a new Ember.js app in the working directory
+    return emberNew()
+      
+      // then generate the `my-blueprint` blueprint called `foo`
+      .then(() => emberGenerate(args))
+
+      // then assert that the files were generated correctly
+      .then(() => expect(file('path/to/file.js'))
+        .to.contain('file contents to match')
+        .to.contain('more file contents\n'))
+      
+      // then destroy the `my-blueprint` blueprint called `foo`
+      .then(() => emberDestroy(args))
+
+      // then assert that the files were destroyed correctly
+      .then(() => expect(file('path/to/file.js')).to.not.exist);
   });
 });
 ```
 
-To generate another blueprint beforehand, you can use the `afterGenerate` hook to do your actual assertions, like in the example below. Be sure to include the `skipInit` option inside the `afterGenerate` hook to prevent re-initializing the temporary project, which can lead to problems.
 
-```js
-it('adapter extends from application adapter if present', function() {
-  return generateAndDestroy(['adapter', 'application'], {
-    afterGenerate: function() {
-      return generateAndDestroy(['adapter', 'foo'], {
-        // prevents this second generateAndDestroy from running init
-        skipInit: true,
-        files: [
-          {
-            file:'app/adapters/foo.js',
-            contains: [
-              "import ApplicationAdapter from './application';"
-            ]
-          }
-        ]
-      });
-    }
-  });
-});
-```
+API Reference
+------------------------------------------------------------------------------
 
-To setup a test project with a `podModulePrefix` or `usePods` setting, use the following options:
+This project exports two major API endpoints for you to use:
 
-```js
-it('blueprint test', function() {
-  return generateAndDestroy(['my-blueprint', 'foo'], {
-    usePods: true,
-    podModulePrefix: true
-  });
-});
-```
+- `require('ember-cli-blueprint-test-helpers/chai')`
 
-To test generating into addons, in-repo-addons, and dummy projects, you can use the `target` option:
+  This endpoint exports the [Chai](http://chaijs.com/) assertion library
+  including the [chai-as-promised](https://github.com/domenic/chai-as-promised)
+  and [chai-files](https://github.com/Turbo87/chai-files) plugins
 
-```js
-it('blueprint test', function() {
-  return generateAndDestroy(['my-blueprint', 'foo'], {
-    // supported options are 'app', 'addon', and 'inRepoAddon'
-    target: 'addon'
-  });
-});
-```
+- `require('ember-cli-blueprint-test-helpers/helpers')`
+
+  This endpoint exports the functions mentioned in the following API reference
+
+---
+
+### `setupTestHooks(scope, options)`
+
+Prepare the test context for the blueprint tests.
+ 
+**Parameters:**
+
+- `{Object} scope` the test context (i.e. `this`)
+- `{Object} [options]` optional parameters
+- `{Number} [options.timeout=20000]` the test timeout in milliseconds 
+- `{Object} [options.tmpenv]` object containing info about the temporary directory for the test. 
+  Defaults to [`lib/helpers/tmp-env.js`](lib/helpers/tmp-env.js)
+
+**Returns:** `{Promise}`
+
+---
+
+### `emberNew(options)`
+
+Create a new Ember.js app or addon in the current working directory.
+
+**Parameters:**
+
+- `{Object} [options]` optional parameters
+- `{String} [options.target='app']` the type of project to create (`app`, `addon` or `in-repo-addon`)
+
+**Returns:** `{Promise}`
+
+---
+
+### `emberGenerate(args)`
+
+Run a blueprint generator.
+
+**Parameters:**
+
+- `{Array.<String>} args` arguments to pass to `ember generate` (e.g. `['my-blueprint', 'foo']`)
+
+**Returns:** `{Promise}`
+
+---
+
+### `emberDestroy(args)`
+
+Run a blueprint destructor.
+
+**Parameters:**
+
+- `{Array.<String>} args` arguments to pass to `ember destroy` (e.g. `['my-blueprint', 'foo']`)
+
+**Returns:** `{Promise}`
+
+---
+
+### `emberGenerateDestroy(args, assertionCallback)`
+
+Run a blueprint generator and the corresponding blueprint destructor while
+checking assertions in between.
+
+**Parameters:**
+
+- `{Array.<String>} args` arguments to pass to `ember generate` (e.g. `['my-blueprint', 'foo']`)
+- `{Function} assertionCallback` the callback function in which the assertions should happen
+
+**Returns:** `{Promise}`
+
+---
+
+### `modifyPackages(packages)`
+
+Modify the dependencies in the `package.json` file of the test project.
+
+**Parameters:**
+
+- `{Array.<Object>} packages` the list of packages that should be added,
+  changed or removed
+
+---
+
+### `setupPodConfig(options)`
+
+Setup `usePods` in `.ember-cli` and/or `podModulePrefix` in `environment.js`.
+
+**Parameters:**
+
+- `{Object} [options]` optional parameters
+- `{Boolean} [options.usePods]` add `usePods` in `.ember-cli`
+- `{Boolean} [options.podModulePrefix]` set `npodModulePrefix` to `app/pods`
+  in `config/environment.js`
+
 
 Used by
--------
+------------------------------------------------------------------------------
 
 - https://github.com/emberjs/ember.js
 - https://github.com/emberjs/data
 - https://github.com/ember-cli/ember-cli-legacy-blueprints
 - https://github.com/simplabs/ember-simple-auth
 - https://github.com/DockYard/ember-suave
+
+
+License
+------------------------------------------------------------------------------
+
+This project is licensed under the [MIT License](https://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ If you need to override or add to any of the hooks, you may pass a function in t
 The options supported are:
 * __timeout__ _(number)_: Duration before test times out.
 * __tmpenv__ _(tmpenv object)_: Object containing info about the temporary directory for the test. Defaults to [`lib/helpers/tmp-env.js`](https://github.com/ember-cli/ember-cli-blueprint-test-helpers/blob/master/lib/helpers/tmp-env.js)
-* __before__ _(function)_: Hook to execute code at the beginning of the before function.
-* __after__ _(function)_: Hook to execute code at the beginning of the after function.
-* __beforeEach__ _(function)_: Hook to execute code at the beginning of the beforeEach function.
-* __afterEach__ _(function)_: Hook to execute code at the beginning of the afterEach function.
 
 Generate and Destroy Test Helpers
 ---------------------------------

--- a/blueprints/blueprint-test/files/__root__/__name__-test.js
+++ b/blueprints/blueprint-test/files/__root__/__name__-test.js
@@ -1,20 +1,22 @@
 'use strict';
 
-var setupTestHooks     = require('ember-cli-blueprint-test-helpers/lib/helpers/setup');
-var BlueprintHelpers   = require('ember-cli-blueprint-test-helpers/lib/helpers/blueprint-helper');
-var generateAndDestroy = BlueprintHelpers.generateAndDestroy;
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+var expect = require('ember-cli-blueprint-test-helpers/chai').expect;
 
 describe('Acceptance: ember generate and destroy <%= blueprintName %>', function() {
   setupTestHooks(this);
-  
-  it('<%= blueprintName %> foo', function() {
-    // pass any additional command line options in the arguments array
-    return generateAndDestroy(['<%= blueprintName %>', 'foo'], {
-      // define files to assert, and their contents
-      files: [
-        // { file: 'app/type/foo.js', contains: ['foo']}
-      ]
-    });
-  });
 
+  it('<%= blueprintName %> foo', function() {
+    var args = ['<%= blueprintName %>', 'foo'];
+
+    // pass any additional command line options in the arguments array
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, (file) => {
+        // expect(file('app/type/foo.js)).to.contain('foo');
+    }));
+  });
 });

--- a/chai.js
+++ b/chai.js
@@ -1,0 +1,9 @@
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiAsPromised);
+chai.use(chaiFiles);
+
+module.exports = chai;
+module.exports.file = chaiFiles.file;

--- a/helpers.js
+++ b/helpers.js
@@ -2,6 +2,7 @@ module.exports = {
   emberNew: require('./lib/ember-new'),
   emberGenerate: require('./lib/ember-generate'),
   emberDestroy: require('./lib/ember-destroy'),
+  emberGenerateDestroy: require('./lib/ember-generate-destroy'),
   modifyPackages: require('./lib/modify-packages'),
   setupPodConfig: require('./lib/setup-pod-config'),
 };

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,7 @@
+module.exports = {
+  emberNew: require('./lib/ember-new'),
+  emberGenerate: require('./lib/ember-generate'),
+  emberDestroy: require('./lib/ember-destroy'),
+  modifyPackages: require('./lib/modify-packages'),
+  setupPodConfig: require('./lib/setup-pod-config'),
+};

--- a/helpers.js
+++ b/helpers.js
@@ -1,4 +1,5 @@
 module.exports = {
+  setupTestHooks: require('./lib/helpers/setup'),
   emberNew: require('./lib/ember-new'),
   emberGenerate: require('./lib/ember-generate'),
   emberDestroy: require('./lib/ember-destroy'),

--- a/lib/ember-destroy.js
+++ b/lib/ember-destroy.js
@@ -1,6 +1,12 @@
 var ember = require('ember-cli/tests/helpers/ember');
 var rethrowFromErrorLog = require('./rethrow-from-error-log');
 
+/**
+ * Run a blueprint destructor.
+ *
+ * @param {Array.<String>} args arguments to pass to `ember destroy` (e.g. `['my-blueprint', 'foo']`)
+ * @returns {Promise}
+ */
 module.exports = function(args) {
   var commandArgs = ['destroy'].concat(args);
 

--- a/lib/ember-destroy.js
+++ b/lib/ember-destroy.js
@@ -1,0 +1,13 @@
+var ember = require('ember-cli/tests/helpers/ember');
+var rethrowFromErrorLog = require('./rethrow-from-error-log');
+
+module.exports = function(args) {
+  var commandArgs = ['destroy'].concat(args);
+
+  var cliOptions = {
+    disableDependencyChecker: true,
+  };
+
+  return ember(commandArgs, cliOptions)
+    .catch(rethrowFromErrorLog);
+};

--- a/lib/ember-generate-destroy.js
+++ b/lib/ember-generate-destroy.js
@@ -5,6 +5,19 @@ var emberDestroy = require('./ember-destroy');
 var expect = chai.expect;
 var file = chai.file;
 
+/**
+ * @callback assertionCallback
+ * @param {file} file
+ */
+
+/**
+ * Run a blueprint generator and the corresponding blueprint destructor while
+ * checking assertions in between.
+ *
+ * @param {Array.<String>} args arguments to pass to `ember generate` (e.g. `['my-blueprint', 'foo']`)
+ * @param {assertionCallback} assertionCallback the callback function in which the assertions should happen
+ * @returns {Promise}
+ */
 module.exports = function(args, assertionCallback) {
   var paths = [];
 

--- a/lib/ember-generate-destroy.js
+++ b/lib/ember-generate-destroy.js
@@ -1,0 +1,28 @@
+var chai = require('../chai');
+var emberGenerate = require('./ember-generate');
+var emberDestroy = require('./ember-destroy');
+
+var expect = chai.expect;
+var file = chai.file;
+
+module.exports = function(args, assertionCallback) {
+  var paths = [];
+
+  var _file = function(path) {
+    paths.push(path);
+    return file(path);
+  };
+
+  return emberGenerate(args)
+    .then(function() { assertionCallback(_file); })
+    .then(function() { return emberDestroy(args); })
+    .then(function() {
+      if (paths.length === 0) {
+        throw new Error('The file() parameter of the emberGenerateDestroy() callback function was never used.');
+      }
+
+      paths.forEach(function(path) {
+        expect(file(path)).to.not.exist;
+      })
+    });
+};

--- a/lib/ember-generate.js
+++ b/lib/ember-generate.js
@@ -1,6 +1,12 @@
 var ember = require('ember-cli/tests/helpers/ember');
 var rethrowFromErrorLog = require('./rethrow-from-error-log');
 
+/**
+ * Run a blueprint generator.
+ *
+ * @param {Array.<String>} args arguments to pass to `ember generate` (e.g. `['my-blueprint', 'foo']`)
+ * @returns {Promise}
+ */
 module.exports = function(args) {
   var commandArgs = ['generate'].concat(args);
 

--- a/lib/ember-generate.js
+++ b/lib/ember-generate.js
@@ -1,0 +1,13 @@
+var ember = require('ember-cli/tests/helpers/ember');
+var rethrowFromErrorLog = require('./rethrow-from-error-log');
+
+module.exports = function(args) {
+  var commandArgs = ['generate'].concat(args);
+
+  var cliOptions = {
+    disableDependencyChecker: true,
+  };
+
+  return ember(commandArgs, cliOptions)
+    .catch(rethrowFromErrorLog);
+};

--- a/lib/ember-new.js
+++ b/lib/ember-new.js
@@ -1,0 +1,46 @@
+var fs = require('fs');
+var path = require('path');
+var existsSync = require('exists-sync');
+
+var ember = require('ember-cli/tests/helpers/ember');
+var modifyPackages = require('./modify-packages');
+var rethrowFromErrorLog = require('./rethrow-from-error-log');
+
+module.exports = function(options) {
+  options = options || {};
+
+  var target = options.target || 'app';
+  var isAddon = (target === 'addon');
+
+  var projectName = isAddon ? 'my-addon' : 'my-app';
+  var command = isAddon ? 'addon' : 'new';
+
+  var cliOptions = {
+    disableDependencyChecker: true
+  };
+
+  return ember([command, projectName, '--skip-npm', '--skip-bower'], cliOptions)
+    .then(generateInRepoAddon(target))
+    .then(linkAddon)
+    .catch(rethrowFromErrorLog);
+};
+
+function generateInRepoAddon(target) {
+  return function() {
+    if (target === 'in-repo-addon') {
+      return ember(['generate', 'in-repo-addon', 'my-addon'])
+    }
+  }
+}
+
+function linkAddon() {
+  var projectPath = path.resolve(process.cwd(), '../../..');
+  var projectName = require(path.resolve(projectPath, 'package.json')).name;
+
+  var symlinkPath = path.resolve(projectPath, 'node_modules', projectName);
+  if (!existsSync(path.resolve(symlinkPath, 'package.json'))) {
+    fs.symlinkSync(projectPath, symlinkPath, 'dir');
+  }
+
+  modifyPackages([{ name: projectName, dev: true }]);
+}

--- a/lib/ember-new.js
+++ b/lib/ember-new.js
@@ -6,6 +6,13 @@ var ember = require('ember-cli/tests/helpers/ember');
 var modifyPackages = require('./modify-packages');
 var rethrowFromErrorLog = require('./rethrow-from-error-log');
 
+/**
+ * Create a new Ember.js app or addon in the current working directory.
+ *
+ * @param {Object} [options] optional parameters
+ * @param {String} [options.target='app'] the type of project to create (`app`, `addon` or `in-repo-addon`)
+ * @returns {Promise}
+ */
 module.exports = function(options) {
   options = options || {};
 

--- a/lib/helpers/setup.js
+++ b/lib/helpers/setup.js
@@ -12,11 +12,12 @@ var tmpenv           = require('./tmp-env');
 var debug            = require('debug')('ember-cli:testing');
 
 /**
-  Setup mocha test hooks
+  Prepare the test context for the blueprint tests.
+
   @method setupTestHooks
   @param {Object} scope
   @param {Object} [options]
-  @param {Number} [options.timeout]
+  @param {Number} [options.timeout=20000]
   @param {Object} [options.tmpenv]
   @return {null}
 */

--- a/lib/helpers/setup.js
+++ b/lib/helpers/setup.js
@@ -14,14 +14,10 @@ var debug            = require('debug')('ember-cli:testing');
 /**
   Setup mocha test hooks
   @method setupTestHooks
-  @param {Object} [scope]
+  @param {Object} scope
   @param {Object} [options]
   @param {Number} [options.timeout]
   @param {Object} [options.tmpenv]
-  @param {Function} [options.before]
-  @param {Function} [options.after]
-  @param {Function} [options.beforeEach]
-  @param {Function} [options.afterEach]
   @return {null}
 */
 module.exports = function setupTestHooks(scope, options) {
@@ -30,34 +26,22 @@ module.exports = function setupTestHooks(scope, options) {
   scope.timeout(timeout);
 
   before(function () {
-    if (options && options.before) {
-      options.before();
-    }
     BlueprintNpmTask.disableNPM(Blueprint);
     conf.setup();
   });
 
   after(function() {
-    if (options && options.after) {
-      options.after();
-    }
     BlueprintNpmTask.restoreNPM(Blueprint);
     conf.restore();
   });
 
   beforeEach(function() {
-    if (options && options.beforeEach) {
-      options.beforeEach();
-    }
     tmp.freshDir();
     process.chdir(tmp.tmpdir);
     debug("beforeEach cwd: " + process.cwd());
   });
 
   afterEach(function() {
-    if (options && options.afterEach) {
-      options.afterEach();
-    }
     debug('afterEach:tmpdir: ', walkSync(tmp.tmpdir));
     this.timeout(10000);
     process.chdir(tmp.root);

--- a/lib/modify-packages.js
+++ b/lib/modify-packages.js
@@ -1,6 +1,12 @@
 var fs = require('fs');
 var path = require('path');
 
+/**
+ * Modify the dependencies in the `package.json` file of the test project.
+ *
+ * @param {Array.<Object>} packages the list of packages that should be added,
+ * changed or removed
+ */
 module.exports = function(packages) {
   var packagePath = path.resolve(process.cwd(), 'package.json');
 

--- a/lib/modify-packages.js
+++ b/lib/modify-packages.js
@@ -1,0 +1,22 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function(packages) {
+  var packagePath = path.resolve(process.cwd(), 'package.json');
+
+  var contents  = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+  contents.dependencies = contents.dependencies || {};
+  contents.devDependencies = contents.devDependencies || {};
+
+  packages.forEach(function(pkg) {
+    if (pkg.delete) {
+      delete contents.dependencies[pkg.name];
+      delete contents.devDependencies[pkg.name];
+    } else {
+      var dependencies = pkg.dev ? contents.devDependencies : contents.dependencies;
+      dependencies[pkg.name] = pkg.version || '*';
+    }
+  });
+
+  fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2));
+};

--- a/lib/rethrow-from-error-log.js
+++ b/lib/rethrow-from-error-log.js
@@ -1,0 +1,7 @@
+module.exports = function(error) {
+  if (error.errorLog && error.errorLog.length) {
+    throw error.errorLog[0];
+  } else {
+    throw error;
+  }
+};

--- a/lib/setup-pod-config.js
+++ b/lib/setup-pod-config.js
@@ -1,0 +1,15 @@
+var replaceFile = require('ember-cli-internal-test-helpers/lib/helpers/file-utils').replaceFile;
+
+module.exports = function(options) {
+  options = options || {};
+
+  // setup usePods for a project in .ember-cli
+  if (options.usePods) {
+    replaceFile('.ember-cli', '"disableAnalytics": false', '"disableAnalytics": false,\n"usePods" : true\n');
+  }
+
+  // setup environment.js with a pre-set podModulePrefix
+  if (options.podModulePrefix) {
+    replaceFile('config/environment.js', 'var ENV = {', 'var ENV = {\npodModulePrefix: \'app/pods\', \n');
+  }
+};

--- a/lib/setup-pod-config.js
+++ b/lib/setup-pod-config.js
@@ -1,5 +1,13 @@
 var replaceFile = require('ember-cli-internal-test-helpers/lib/helpers/file-utils').replaceFile;
 
+/**
+ * Setup `usePods` in `.ember-cli` and/or `podModulePrefix` in `environment.js`.
+ *
+ * @param {Object} [options] optional parameters
+ * @param {Boolean} [options.usePods] add `usePods` in `.ember-cli`
+ * @param {Boolean} [options.podModulePrefix] set `npodModulePrefix` to
+ * `app/pods` in `config/environment.js`
+ */
 module.exports = function(options) {
   options = options || {};
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
+    "chai-files": "^1.0.0",
     "debug": "^2.2.0",
     "ember-cli-internal-test-helpers": "^0.8.1",
     "exists-sync": "0.0.3",


### PR DESCRIPTION
I'd like to propose a substantial API change for these helpers that should resolve #38, simplify the whole process of writing assertions and also greatly simplify our own code in this project.

Some examples:

```js
  it('route foo', function() {
    var args = ['route', 'foo'];

    return emberNew()
      .then(() => emberGenerate(args))
      .then(() => expect(file('app/routes/foo.js'))
        .to.contain('import Ember from \'ember\';')
        .to.contain('export default Ember.Route.extend({\n});'))

      .then(() => expect(file('app/templates/foo.hbs'))
        .to.contain('{{outlet}}'))

      .then(() => expect(file('tests/unit/routes/foo-test.js'))
        .to.contain('import { moduleFor, test } from \'ember-qunit\';')
        .to.contain('moduleFor(\'route:foo\''))

      .then(() => expect(file('app/router.js'))
        .to.contain('this.route(\'foo\')'))

      .then(() => emberDestroy(args))
      .then(() => expect(file('app/routes/foo.js')).to.not.exist)
      .then(() => expect(file('app/templates/foo.hbs')).to.not.exist)
      .then(() => expect(file('tests/unit/routes/foo-test.js')).to.not.exist)
      .then(() => expect(file('app/router.js'))
        .to.not.contain('this.route(\'foo\')'));
  });
```

```js
  it('adapter throws when --base-class is same as name', function() {
    var args = ['adapter', 'foo', '--base-class=foo'];

    return emberNew()
      .then(() => expect(emberGenerate(args))
        .to.be.rejectedWith(SilentError, /Adapters cannot extend from themself/));
  });
```

with async/await:

```js

  it('route foo', async function() {
    var args = ['route', 'foo'];

    await emberNew();
    await emberGenerate(args);

    expect(file('app/routes/foo.js'))
      .to.contain('import Ember from \'ember\';')
      .to.contain('export default Ember.Route.extend({\n});');

    expect(file('app/templates/foo.hbs'))
      .to.contain('{{outlet}}');

    expect(file('tests/unit/routes/foo-test.js'))
      .to.contain('import { moduleFor, test } from \'ember-qunit\';')
      .to.contain('moduleFor(\'route:foo\'');

    expect(file('app/router.js'))
      .to.contain('this.route(\'foo\')');

    await emberDestroy(args);

    expect(file('app/routes/foo.js')).to.not.exist;
    expect(file('app/templates/foo.hbs')).to.not.exist;
    expect(file('tests/unit/routes/foo-test.js')).to.not.exist;
    expect(file('app/router.js'))
      .to.not.contain('this.route(\'foo\')');
  });
```

I've experimented with this API already in the legacy blueprints project and you can find my converted code at https://github.com/Turbo87/ember-cli-legacy-blueprints/commits/bp-v2.

We can probably support both APIs for a certain amount of time to make the transition easier for everyone that's using the current API.

Note that this is work-in-progress and not everything is polished yet, but the general concept seems to work very well.

/cc @trabus @stefanpenner @rwjblue @kellyselden @nathanhammond 