### PR TITLE
Rename `contents` to `contains` in example assertion

### DIFF
--- a/blueprints/blueprint-test/files/__root__/__name__-test.js
+++ b/blueprints/blueprint-test/files/__root__/__name__-test.js
@@ -12,7 +12,7 @@ describe('Acceptance: ember generate and destroy <%= blueprintName %>', function
     return generateAndDestroy(['<%= blueprintName %>', 'foo'], {
       // define files to assert, and their contents
       files: [
-        // { file: 'app/type/foo.js', contents: ['foo']}
+        // { file: 'app/type/foo.js', contains: ['foo']}
       ]
     });
   });


### PR DESCRIPTION
Fixing this so other people don't have to [scratch their heads like I did](https://github.com/kimroen/ember-cli-coffeescript/pull/106#issuecomment-200522734) :see_no_evil: (Thanks for helping out, @trabus!)