### PR TITLE
blueprint-helper: Explicitly use "chai-as-promised"

### DIFF
--- a/lib/helpers/blueprint-helper.js
+++ b/lib/helpers/blueprint-helper.js
@@ -5,7 +5,6 @@ var Promise     = require('ember-cli/lib/ext/promise');
 var path        = require('path');
 var findup      = Promise.denodeify(require('findup'));
 var initProject = require('./project-init');
-var expect      = require('chai').expect;
 var walkSync    = require('walk-sync');
 var assertFile  = require('ember-cli-internal-test-helpers/lib/helpers/assert-file');
 var assertFileToNotExist  = require('ember-cli-internal-test-helpers/lib/helpers/assert-file-to-not-exist');
@@ -13,6 +12,10 @@ var tmpenv      = require('./tmp-env');
 var debug       = require('debug')('ember-cli:testing');
 var fs          = require('fs');
 var teardownProject = require('./project-teardown');
+
+var chai = require('chai');
+chai.use(require('chai-as-promised'));
+var expect = chai.expect;
 
 /**
   Generate blueprint then assert generated contents against options.files


### PR DESCRIPTION
Missing this resulted in "TypeError: expect(...).to.be.rejectedWith is not a function" (see https://github.com/emberjs/data/pull/4023)

/cc @trabus 