### PR TITLE
Dependency clean and updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "exists-sync": "0.0.3",
     "findup": "^0.1.5",
     "fs-extra": "^0.26.7",
-    "rsvp": "^3.0.17",
     "tmp-sync": "^1.0.0",
     "walk-sync": "^0.2.5"
   },
@@ -40,6 +39,7 @@
     "glob": "5.0.13",
     "mocha": "^2.2.1",
     "mocha-only-detector": "^0.1.0",
-    "rimraf": "^2.4.3"
+    "rimraf": "^2.4.3",
+    "rsvp": "^3.0.17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-internal-test-helpers": "^0.8.1",
     "exists-sync": "0.0.3",
     "findup": "^0.1.5",
-    "fs-extra": "^0.24.0",
+    "fs-extra": "^0.26.7",
     "glob": "5.0.13",
     "rsvp": "^3.0.17",
     "tmp-sync": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "^2.2.0",
     "eslint-plugin-chai-expect": "^1.0.0",
     "glob": "5.0.13",
-    "mocha": "^2.2.1",
+    "mocha": "^2.4.5",
     "mocha-only-detector": "^0.1.0",
     "rimraf": "^2.4.3",
     "rsvp": "^3.0.17"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint": "^2.2.0",
     "eslint-plugin-chai-expect": "^1.0.0",
     "mocha": "^2.2.1",
-    "mocha-only-detector": "0.0.2",
+    "mocha-only-detector": "^0.1.0",
     "rimraf": "^2.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "exists-sync": "0.0.3",
     "findup": "^0.1.5",
     "fs-extra": "^0.26.7",
-    "glob": "5.0.13",
     "rsvp": "^3.0.17",
     "tmp-sync": "^1.0.0",
     "walk-sync": "^0.2.5"
@@ -38,6 +37,7 @@
     "ember-cli": "^2.3.0",
     "eslint": "^2.2.0",
     "eslint-plugin-chai-expect": "^1.0.0",
+    "glob": "5.0.13",
     "mocha": "^2.2.1",
     "mocha-only-detector": "^0.1.0",
     "rimraf": "^2.4.3"


### PR DESCRIPTION
This PR updates a few dependencies and moves two from `dependencies` to `devDependencies` that are only needed by our test runner.