### PR TITLE
Add babel option for default blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Run the following command to generate the test runner:
 ember generate ember-cli-blueprint-test-helpers
 ```
 
-If you are using `ember-cli-blueprint-test-helpers` on Node v4.x or lower, you'll want to use the `-babel` option, to add ES6 support.
+If you are using `ember-cli-blueprint-test-helpers` on Node v4.x or lower, you'll want to use the `--babel` option, to add ES6 support.
 ```
-ember generate ember-cli-blueprint-test-helpers -babel
+ember generate ember-cli-blueprint-test-helpers --babel
 ```
 
 It should be noted that `ember-cli-blueprint-test-helpers` currently [only works for testing blueprints inside addon projects](https://github.com/ember-cli/ember-cli-blueprint-test-helpers/issues/56).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Run the following command to generate the test runner:
 ember generate ember-cli-blueprint-test-helpers
 ```
 
+If you are using `ember-cli-blueprint-test-helpers` on Node v4.x or lower, you'll want to use the `-babel` option, to add ES6 support.
+```
+ember generate ember-cli-blueprint-test-helpers -babel
+```
 
 Usage
 ------------------------------------------------------------------------------
@@ -69,7 +73,7 @@ describe('Acceptance: ember generate and destroy my-blueprint', function() {
 
     // create a new Ember.js app in the working directory
     return emberNew()
-      
+
       // then generate and destroy the `my-blueprint` blueprint called `foo`
       .then(() => emberGenerateDestroy(args, (file) => {
 
@@ -78,8 +82,8 @@ describe('Acceptance: ember generate and destroy my-blueprint', function() {
           .to.contain('file contents to match')
           .to.contain('more file contents\n');
       }));
-      
-     // magically done for you: assert that the generated files are destroyed again 
+
+     // magically done for you: assert that the generated files are destroyed again
   });
 });
 ```
@@ -96,7 +100,7 @@ describe('Acceptance: ember generate and destroy my-blueprint', function() {
 
     // create a new Ember.js app in the working directory
     return emberNew()
-      
+
       // then generate the `my-blueprint` blueprint called `foo`
       .then(() => emberGenerate(args))
 
@@ -104,7 +108,7 @@ describe('Acceptance: ember generate and destroy my-blueprint', function() {
       .then(() => expect(file('path/to/file.js'))
         .to.contain('file contents to match')
         .to.contain('more file contents\n'))
-      
+
       // then destroy the `my-blueprint` blueprint called `foo`
       .then(() => emberDestroy(args))
 
@@ -113,7 +117,6 @@ describe('Acceptance: ember generate and destroy my-blueprint', function() {
   });
 });
 ```
-
 
 API Reference
 ------------------------------------------------------------------------------
@@ -135,13 +138,13 @@ This project exports two major API endpoints for you to use:
 ### `setupTestHooks(scope, options)`
 
 Prepare the test context for the blueprint tests.
- 
+
 **Parameters:**
 
 - `{Object} scope` the test context (i.e. `this`)
 - `{Object} [options]` optional parameters
-- `{Number} [options.timeout=20000]` the test timeout in milliseconds 
-- `{Object} [options.tmpenv]` object containing info about the temporary directory for the test. 
+- `{Number} [options.timeout=20000]` the test timeout in milliseconds
+- `{Object} [options.tmpenv]` object containing info about the temporary directory for the test.
   Defaults to [`lib/helpers/tmp-env.js`](lib/helpers/tmp-env.js)
 
 **Returns:** `{Promise}`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ If you are using `ember-cli-blueprint-test-helpers` on Node v4.x or lower, you'l
 ember generate ember-cli-blueprint-test-helpers -babel
 ```
 
+It should be noted that `ember-cli-blueprint-test-helpers` currently [only works for testing blueprints inside addon projects](https://github.com/ember-cli/ember-cli-blueprint-test-helpers/issues/56).
+
 Usage
 ------------------------------------------------------------------------------
 

--- a/blueprints/blueprint-test/files/__root__/__name__-test.js
+++ b/blueprints/blueprint-test/files/__root__/__name__-test.js
@@ -16,7 +16,7 @@ describe('Acceptance: ember generate and destroy <%= blueprintName %>', function
     // pass any additional command line options in the arguments array
     return emberNew()
       .then(() => emberGenerateDestroy(args, (file) => {
-        // expect(file('app/type/foo.js)).to.contain('foo');
+        // expect(file('app/type/foo.js')).to.contain('foo');
     }));
   });
 });

--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -1,12 +1,37 @@
 var Promise = require('ember-cli/lib/ext/promise');
+var existsSync = require('exists-sync');
+var path = require('path');
 
 module.exports = {
   description: 'Installs dependencies for ember-cli-blueprint-test-helpers',
+  availableOptions: [
+    {
+      name: 'babel',
+      type: Boolean,
+      default: false
+    }
+  ],
   normalizeEntityName: function(){},
-  afterInstall: function() {
-    return Promise.all([
+  afterInstall: function(options) {
+    var afterInstallTasks = [
       this.insertIntoFile('./.npmignore', 'node-tests/'),
-      this.addPackageToProject('mocha', '^2.2.1'),
-    ]);
+      this.addPackageToProject('mocha', '^2.2.1')
+    ];
+    if (options.babel) {
+      afterInstallTasks.splice(0, 0,
+        this.insertIntoFile('./node-tests/mocha.opts', '--require babel-register\n--recursive'),
+        this.addPackagesToProject([
+          {name: 'babel-plugin-transform-es2015-arrow-functions', target: '^6.5.2'},
+          {name: 'babel-plugin-transform-es2015-shorthand-properties', target: '^6.5.0'},
+          {name: 'babel-register', target: '^6.7.2'}
+        ]));
+      if (existsSync(path.resolve('./node-tests/.babelrc'))) {
+        afterInstallTasks.splice(0, 0,this.insertIntoFile('./node-tests/.babelrc','\n\t\t"transform-es2015-arrow-functions",\n\t\t"transform-es2015-shorthand-properties"\n', {after: '"plugins": ['}));
+      } else {
+        afterInstallTasks.splice(0, 0, this.insertIntoFile('./node-tests/.babelrc','{\n\t"plugins": [\n\t\t"transform-es2015-arrow-functions",\n\t\t"transform-es2015-shorthand-properties"\n\t]\n}'));
+      }
+    }
+    // console.log('ADDING TO BABEL', options);
+    return Promise.all(afterInstallTasks);
   }
 };

--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -2,7 +2,7 @@ var Promise = require('ember-cli/lib/ext/promise');
 var existsSync = require('exists-sync');
 var fs = require('fs-extra');
 var path = require('path');
-var merge = require('lodash/merge');
+var merge = require('lodash.merge');
 var writeFile = Promise.denodeify(fs.outputFile);
 
 module.exports = {
@@ -18,22 +18,20 @@ module.exports = {
   afterInstall: function(options) {
     var afterInstallTasks = [
       this.insertIntoFile('./.npmignore', 'node-tests/'),
-      this.addPackageToProject('mocha', '^2.2.1')
+      this.insertTestCallToPackage(options)
     ];
+    var packages = [{name: 'mocha', target: '^2.2.1'}];
+
     if (options.babel) {
-      afterInstallTasks.splice(0, 0,
-        this.insertIntoFile('./node-tests/mocha.opts', '--require babel-register\n--recursive'),
-        this.addPackagesToProject([
-          {name: 'babel-plugin-transform-es2015-arrow-functions', target: '^6.5.2'},
+      afterInstallTasks.push(this.insertIntoJsonFile('./node-tests/.babelrc',{plugins: ["transform-es2015-arrow-functions", "transform-es2015-shorthand-properties"]}));
+      // add babel specific packages
+      packages.push({name: 'babel-plugin-transform-es2015-arrow-functions', target: '^6.5.2'},
           {name: 'babel-plugin-transform-es2015-shorthand-properties', target: '^6.5.0'},
-          {name: 'babel-register', target: '^6.7.2'}
-        ]),
-        this.insertIntoJsonFile('./node-tests/.babelrc',{plugins: ["transform-es2015-arrow-functions", "transform-es2015-shorthand-properties"]})
-      );
+          {name: 'babel-register', target: '^6.7.2'});
     }
+    afterInstallTasks.push(this.addPackagesToProject(packages));
     return Promise.all(afterInstallTasks);
   },
-  //TODO: Add this functionality upstream to ember-cli insertIntoFile
   insertIntoJsonFile: function(pathRelativeToProjectRoot, contents) {
     var fullPath = path.join(this.project.root, pathRelativeToProjectRoot);
     var contentsToWrite;
@@ -42,6 +40,40 @@ module.exports = {
       originalContents = JSON.parse(fs.readFileSync(fullPath, { encoding: 'utf8' }));
     }
     contentsToWrite = JSON.stringify(merge(originalContents, contents), null, 2);
+    var returnValue = {
+      path: fullPath,
+      originalContents: originalContents,
+      contents: contentsToWrite,
+      inserted: false
+    };
+    if (contentsToWrite !== originalContents) {
+      returnValue.inserted = true;
+
+      return writeFile(fullPath, contentsToWrite)
+        .then(function() {
+          return returnValue;
+        });
+    } else {
+      return Promise.resolve(returnValue);
+    }
+  },
+  insertTestCallToPackage: function(options) {
+    var contentsToWrite;
+    var fullPath = path.join(this.project.root, 'package.json');
+    var scriptContents = 'mocha node-tests --recursive';
+    var babelContents = ' --require babel-register';
+    var originalContents = fs.readJsonSync(fullPath, { throws: false });
+    if (originalContents.scripts.nodetest === scriptContents) {
+      if (options.babel) {
+        originalContents.scripts.nodetest += babelContents;
+      }
+    } else if (typeof originalContents.scripts.nodetest === 'undefined') {
+      originalContents.scripts.nodetest = scriptContents + (options.babel ? babelContents : '');
+    } else {
+      this.ui.writeLine('Could not update "nodetest" script in package.json. Please add "' + scriptContents +
+        (options.babel ? babelContents : '') + '" to your nodetest script.');
+    }
+    contentsToWrite = JSON.stringify(originalContents, null, 2);
     var returnValue = {
       path: fullPath,
       originalContents: originalContents,

--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -20,8 +20,7 @@ module.exports = {
       this.insertIntoFile('./.npmignore', 'node-tests/')
     ];
     var packages = [{name: 'mocha', target: '^2.2.1'}];
-    // write the test call to the package.json
-    this.insertTestCallToPackage(options);
+    this.insertTestCallToPackage(options)
 
     if (options.babel) {
       afterInstallTasks.push(this.insertIntoJsonFile('./node-tests/.babelrc',{plugins: ["transform-es2015-arrow-functions", "transform-es2015-shorthand-properties"]}));
@@ -41,21 +40,10 @@ module.exports = {
       originalContents = JSON.parse(fs.readFileSync(fullPath, { encoding: 'utf8' }));
     }
     contentsToWrite = JSON.stringify(merge(originalContents, contents), null, 2);
-    var returnValue = {
-      path: fullPath,
-      originalContents: originalContents,
-      contents: contentsToWrite,
-      inserted: false
-    };
     if (contentsToWrite !== originalContents) {
-      returnValue.inserted = true;
-
-      return writeFile(fullPath, contentsToWrite)
-        .then(function() {
-          return returnValue;
-        });
+      return writeFile(fullPath, contentsToWrite);
     } else {
-      return Promise.resolve(returnValue);
+      return Promise.resolve();
     }
   },
   insertTestCallToPackage: function(options) {

--- a/node-tests/blueprints/blueprint-test-test.js
+++ b/node-tests/blueprints/blueprint-test-test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var blueprintHelpers = require('../../helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+
+var expect = require('../../chai').expect;
+
+describe('Acceptance: ember generate and destroy blueprint-test', function() {
+  setupTestHooks(this);
+
+  it('blueprint-test foo', function() {
+    var args = ['blueprint-test', 'foo'];
+
+    // pass any additional command line options in the arguments array
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, file => {
+        expect(file('node-tests/blueprints/foo-test.js')).to.contain('describe(\'Acceptance: ember generate and destroy foo\', function() {');
+    }));
+  });
+});

--- a/node-tests/blueprints/ember-cli-blueprint-test-helpers-test.js
+++ b/node-tests/blueprints/ember-cli-blueprint-test-helpers-test.js
@@ -24,7 +24,7 @@ describe('Acceptance: ember generate and destroy ember-cli-blueprint-test-helper
         expect(file('.npmignore')).to.contain('node-tests/');
     }));
   });
-  it('ember-cli-blueprint-test-helpers', function() {
+  it('ember-cli-blueprint-test-helpers -babel', function() {
     var args = ['ember-cli-blueprint-test-helpers', '-babel'];
 
     // pass any additional command line options in the arguments array

--- a/node-tests/blueprints/ember-cli-blueprint-test-helpers-test.js
+++ b/node-tests/blueprints/ember-cli-blueprint-test-helpers-test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var blueprintHelpers = require('../../helpers');
+var setupTestHooks = blueprintHelpers.setupTestHooks;
+var emberNew = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var emberGenerate = blueprintHelpers.emberGenerate;
+
+var expect = require('../../chai').expect;
+var file = require('../../chai').file;
+
+describe('Acceptance: ember generate and destroy ember-cli-blueprint-test-helpers', function() {
+  setupTestHooks(this);
+
+  it('ember-cli-blueprint-test-helpers', function() {
+    var args = ['ember-cli-blueprint-test-helpers'];
+
+    // pass any additional command line options in the arguments array
+    return emberNew()
+      .then(() => emberGenerate(args)
+      .then((result) => {
+        // test ui output because we can't test for actual npm install modifying package.json
+        expect(result.outputStream.join(' ')).to.contain('install package\u001b[39m mocha');
+        expect(file('.npmignore')).to.contain('node-tests/');
+    }));
+  });
+  it('ember-cli-blueprint-test-helpers', function() {
+    var args = ['ember-cli-blueprint-test-helpers', '-babel'];
+
+    // pass any additional command line options in the arguments array
+    return emberNew()
+      .then(() => emberGenerate(args)
+      .then((result) => {
+        let output = result.outputStream.join('');
+        // test ui output because we can't test for actual npm install modifying package.json
+        expect(output).to.contain('babel-register')
+        expect(output).to.contain('babel-plugin-transform-es2015-arrow-functions')
+        expect(output).to.contain('babel-plugin-transform-es2015-shorthand-properties');
+
+        expect(file('node-tests/.babelrc'))
+          .to.contain('"plugins": [')
+          .to.contain('"transform-es2015-arrow-functions",')
+          .to.contain('"transform-es2015-shorthand-properties"')
+        expect(file('node-tests/mocha.opts'))
+          .to.contain('--require babel-register\n--recursive');
+    }));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "exists-sync": "0.0.3",
     "findup": "^0.1.5",
     "fs-extra": "^0.26.7",
+    "lodash.merge": "^4.4.0",
     "tmp-sync": "^1.0.0",
     "walk-sync": "^0.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "mocha tests/lint-test",
-    "test": "mocha tests --recursive"
+    "test": "mocha tests node-tests --recursive"
   },
   "ember-addon": {
     "main": "index.js"


### PR DESCRIPTION
This PR adds the option to install babel dependencies for projects that need to test in node versions that don't support arrow functions natively. The user can run the default blueprint manually with the `-babel` option to install `babel-register`, `babel-plugin-transform-es2015-arrow-functions`, and `babel-plugin-transform-es2015-shorthand-properties`, with an accompanying `.babelrc`. Also, a `mocha.opts` file is added with `--require babel-register`.

Also added blueprint tests for `blueprint-test` and the default blueprint for `ember-cli-blueprint-test-helpers`. 

Still a WIP, I want to add documentation and clean up a few other things.