### PR TITLE
Move rsvp out of dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "findup": "^0.1.5",
     "fs-extra": "^0.26.7",
     "lodash.merge": "^4.4.0",
+    "rsvp": "^3.0.17",
     "tmp-sync": "^1.0.0",
     "walk-sync": "^0.2.5"
   },
@@ -40,7 +41,6 @@
     "mocha": "^2.4.5",
     "mocha-eslint": "^2.0.2",
     "mocha-only-detector": "^0.1.0",
-    "rimraf": "^2.4.3",
-    "rsvp": "^3.0.17"
+    "rimraf": "^2.4.3"
   }
 }


### PR DESCRIPTION
It seems like `rsvp` is actually a dependency of ember-cli-blueprint-test-helpers. Was finding it missing when trying to run tests for ember-cli-template-lint.

This PR moves `rsvp` to be a dependency and not a dev dependency for npm.

```
> ember-cli-template-lint@0.4.9 test-node /Users/ben/src/ember-cli-template-lint
> node node-tests/nodetest-runner.js

Error: Cannot find module 'rsvp'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/ben/src/ember-cli-template-lint/node_modules/ember-cli-blueprint-test-helpers/lib/helpers/setup.js:3:24)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
```