### PR TITLE
Decouple from Ember CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Prepare the test context for the blueprint tests.
 - `{Object} [options]` optional parameters
 - `{Number} [options.timeout=20000]` the test timeout in milliseconds
 - `{Object} [options.tmpenv]` object containing info about the temporary directory for the test.
+- `{String} [options.cliPath='ember-cli']` path to the `ember-cli` dependency
   Defaults to [`lib/helpers/tmp-env.js`](lib/helpers/tmp-env.js)
 
 **Returns:** `{Promise}`

--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -1,9 +1,11 @@
-var Promise = require('ember-cli/lib/ext/promise');
+var RSVP = require('rsvp');
 var existsSync = require('exists-sync');
 var fs = require('fs-extra');
 var path = require('path');
 var merge = require('lodash.merge');
-var writeFile = Promise.denodeify(fs.outputFile);
+
+var Promise = RSVP.Promise;
+var writeFile = RSVP.denodeify(fs.outputFile);
 
 module.exports = {
   description: 'Installs dependencies for ember-cli-blueprint-test-helpers',

--- a/lib/ember-destroy.js
+++ b/lib/ember-destroy.js
@@ -1,4 +1,4 @@
-var ember = require('ember-cli/tests/helpers/ember');
+var ember = require('./helpers/ember');
 var rethrowFromErrorLog = require('./rethrow-from-error-log');
 
 /**

--- a/lib/ember-generate.js
+++ b/lib/ember-generate.js
@@ -1,4 +1,4 @@
-var ember = require('ember-cli/tests/helpers/ember');
+var ember = require('./helpers/ember');
 var rethrowFromErrorLog = require('./rethrow-from-error-log');
 
 /**

--- a/lib/ember-new.js
+++ b/lib/ember-new.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var existsSync = require('exists-sync');
 
-var ember = require('ember-cli/tests/helpers/ember');
+var ember = require('./helpers/ember');
 var modifyPackages = require('./modify-packages');
 var rethrowFromErrorLog = require('./rethrow-from-error-log');
 

--- a/lib/helpers/ember.js
+++ b/lib/helpers/ember.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var requireFromCLI = require('./require-from-cli');
+
 function ember() {
-  return require('ember-cli/tests/helpers/ember').apply(this, arguments);
+  return requireFromCLI('tests/helpers/ember').apply(this, arguments);
 }
 
 module.exports = ember;

--- a/lib/helpers/ember.js
+++ b/lib/helpers/ember.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function ember() {
+  return require('ember-cli/tests/helpers/ember').apply(this, arguments);
+}
+
+module.exports = ember;

--- a/lib/helpers/require-from-cli.js
+++ b/lib/helpers/require-from-cli.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var basePath = 'ember-cli';
+
+function requireFromCLI(path) {
+  return require(basePath + '/' + path);
+}
+
+requireFromCLI.setBasePath = function(path) {
+  basePath = path;
+};
+
+module.exports = requireFromCLI;

--- a/lib/helpers/setup.js
+++ b/lib/helpers/setup.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var RSVP             = require('rsvp');
-var Blueprint        = require('ember-cli/lib/models/blueprint');
 var conf             = require('ember-cli-internal-test-helpers/lib/helpers/conf');
 var BlueprintNpmTask = require('ember-cli-internal-test-helpers/lib/helpers/disable-npm-on-blueprint');
 var fs               = require('fs-extra');
@@ -10,6 +9,7 @@ var existsSync       = require('exists-sync');
 var remove           = RSVP.denodeify(fs.remove);
 var tmpenv           = require('./tmp-env');
 var debug            = require('debug')('ember-cli:testing');
+var requireFromCLI = require('./require-from-cli');
 
 /**
   Prepare the test context for the blueprint tests.
@@ -19,11 +19,18 @@ var debug            = require('debug')('ember-cli:testing');
   @param {Object} [options]
   @param {Number} [options.timeout=20000]
   @param {Object} [options.tmpenv]
+  @param {String} [options.cliPath='ember-cli'] path to the `ember-cli` dependency
 */
 module.exports = function setupTestHooks(scope, options) {
   var timeout = options && options.timeout || 20000;
   var tmp = options && options.tmpenv || scope.tmpenv || tmpenv;
   scope.timeout(timeout);
+
+  if (options && options.cliPath) {
+    requireFromCLI.setBasePath(options.cliPath);
+  }
+
+  var Blueprint = requireFromCLI('lib/models/blueprint');
 
   before(function () {
     BlueprintNpmTask.disableNPM(Blueprint);


### PR DESCRIPTION
This PR makes the Ember CLI imports configurable. This enables us to use this project in Ember CLI itself where `require('ember-cli/something')` doesn't work.

Example:
```js
setupTestHooks(this, {
  cliPath: path.resolve(__dirname + '/../../..'),
});
```

I'd like to release this as v0.13.0 rather soon so that we can begin using it in Ember CLI. This is currently blocking https://github.com/ember-cli/ember-cli/issues/5971.

@stefanpenner @trabus r?