### PR TITLE
Remove obsolete --babel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,12 @@ test helpers for [ember-cli](https://github.com/ember-cli/ember-cli) blueprints
 Installation
 ------------------------------------------------------------------------------
 
-Install the helpers via npm:
-
 ```
-npm install --save-dev ember-cli-blueprint-test-helpers
+ember install ember-cli-blueprint-test-helpers
 ```
 
-Run the following command to generate the test runner:
-
-```
-ember generate ember-cli-blueprint-test-helpers
-```
-
-If you are using `ember-cli-blueprint-test-helpers` on Node v4.x or lower, you'll want to use the `--babel` option, to add ES6 support.
-```
-ember generate ember-cli-blueprint-test-helpers --babel
-```
-
-It should be noted that `ember-cli-blueprint-test-helpers` currently [only works for testing blueprints inside addon projects](https://github.com/ember-cli/ember-cli-blueprint-test-helpers/issues/56).
+It should be noted that `ember-cli-blueprint-test-helpers` currently
+[only works for testing blueprints inside addon projects](https://github.com/ember-cli/ember-cli-blueprint-test-helpers/issues/56).
 
 Usage
 ------------------------------------------------------------------------------

--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -1,70 +1,34 @@
 var RSVP = require('rsvp');
-var existsSync = require('exists-sync');
 var fs = require('fs-extra');
 var path = require('path');
-var merge = require('lodash.merge');
 
 var Promise = RSVP.Promise;
-var writeFile = RSVP.denodeify(fs.outputFile);
 
 module.exports = {
   description: 'Installs dependencies for ember-cli-blueprint-test-helpers',
-  availableOptions: [
-    {
-      name: 'babel',
-      type: Boolean,
-      default: false
-    }
-  ],
-  normalizeEntityName: function(){},
-  afterInstall: function(options) {
-    var afterInstallTasks = [
-      this.insertIntoFile('./.npmignore', 'node-tests/')
-    ];
-    var packages = [{name: 'mocha', target: '^2.2.1'}];
-    this.insertTestCallToPackage(options)
 
-    if (options.babel) {
-      afterInstallTasks.push(this.insertIntoJsonFile('./node-tests/.babelrc',{plugins: ["transform-es2015-arrow-functions", "transform-es2015-shorthand-properties"]}));
-      // add babel specific packages
-      packages.push({name: 'babel-plugin-transform-es2015-arrow-functions', target: '^6.5.2'},
-          {name: 'babel-plugin-transform-es2015-shorthand-properties', target: '^6.5.0'},
-          {name: 'babel-register', target: '^6.7.2'});
-    }
-    afterInstallTasks.push(this.addPackagesToProject(packages));
-    return Promise.all(afterInstallTasks);
+  normalizeEntityName: function() {},
+
+  afterInstall: function(options) {
+    this.insertTestCallToPackage(options);
+
+    return Promise.all([
+      this.insertIntoFile('./.npmignore', 'node-tests/'),
+      this.addPackagesToProject([{name: 'mocha', target: '^2.2.1'}]),
+    ]);
   },
-  insertIntoJsonFile: function(pathRelativeToProjectRoot, contents) {
-    var fullPath = path.join(this.project.root, pathRelativeToProjectRoot);
-    var contentsToWrite;
-    var originalContents = {};
-    if (existsSync(fullPath)) {
-      originalContents = JSON.parse(fs.readFileSync(fullPath, { encoding: 'utf8' }));
-    }
-    contentsToWrite = JSON.stringify(merge(originalContents, contents), null, 2);
-    if (contentsToWrite !== originalContents) {
-      return writeFile(fullPath, contentsToWrite);
-    } else {
-      return Promise.resolve();
-    }
-  },
-  insertTestCallToPackage: function(options) {
+
+  insertTestCallToPackage: function() {
     var insert = false;
     var fullPath = path.join(this.project.root, 'package.json');
     var scriptContents = 'mocha node-tests --recursive';
-    var babelContents = ' --require babel-register';
     var packageContents = fs.readJsonSync(fullPath, { throws: false });
-    if (packageContents.scripts.nodetest === scriptContents) {
-      if (options.babel) {
-        packageContents.scripts.nodetest += babelContents;
-        insert = true;
-      }
-    } else if (typeof packageContents.scripts.nodetest === 'undefined') {
-      packageContents.scripts.nodetest = scriptContents + (options.babel ? babelContents : '');
+    if (!('nodetest' in packageContents.scripts)) {
+      packageContents.scripts.nodetest = scriptContents;
       insert = true;
     } else {
       this.ui.writeLine('Could not update "nodetest" script in package.json. Please add "' + scriptContents +
-        (options.babel ? babelContents : '') + '" to your nodetest script.');
+        '" to your nodetest script.');
     }
 
     if (insert) {

--- a/node-tests/blueprints/ember-cli-blueprint-test-helpers-test.js
+++ b/node-tests/blueprints/ember-cli-blueprint-test-helpers-test.js
@@ -27,29 +27,9 @@ describe('Acceptance: ember generate ember-cli-blueprint-test-helpers', function
         expect(file('.npmignore')).to.contain('node-tests/');
       });
   });
-  it('ember-cli-blueprint-test-helpers -babel', function() {
-    var args = ['ember-cli-blueprint-test-helpers', '--babel'];
 
-    // pass any additional command line options in the arguments array
-    return emberNew()
-      .then(() => emberGenerate(args))
-      .then((result) => {
-        let output = result.outputStream.join('');
-        // test ui output because we can't test for actual npm install modifying package.json
-        expect(output).to.contain('babel-register');
-        expect(output).to.contain('babel-plugin-transform-es2015-arrow-functions');
-        expect(output).to.contain('babel-plugin-transform-es2015-shorthand-properties');
-
-        expect(file('node-tests/.babelrc'))
-          .to.contain('"plugins": [')
-          .to.contain('"transform-es2015-arrow-functions",')
-          .to.contain('"transform-es2015-shorthand-properties"');
-        expect(file('package.json'))
-          .to.contain('--recursive --require babel-register');
-      });
-  });
   it('doesn\'t write to existing nodetest scripts', function() {
-    var args = ['ember-cli-blueprint-test-helpers', '--babel'];
+    var args = ['ember-cli-blueprint-test-helpers'];
 
     // pass any additional command line options in the arguments array
     return emberNew()
@@ -63,7 +43,7 @@ describe('Acceptance: ember generate ember-cli-blueprint-test-helpers', function
       .then(() => emberGenerate(args))
       .then((result) => {
         let output = result.outputStream.join('');
-        expect(output).to.contain('Could not update "nodetest" script in package.json. Please add "mocha node-tests --recursive --require babel-register" to your nodetest script.');
+        expect(output).to.contain('Could not update "nodetest" script in package.json. Please add "mocha node-tests --recursive" to your nodetest script.');
         expect(file('package.json')).to.contain('mocha tests');
       });
   });


### PR DESCRIPTION
This was only necessary for Node 0.x, but those days are finally over... 🎉 