### PR TITLE
mock bower install as well as npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Prepare the test context for the blueprint tests.
 - `{Number} [options.timeout=20000]` the test timeout in milliseconds
 - `{Object} [options.tmpenv]` object containing info about the temporary directory for the test.
 - `{String} [options.cliPath='ember-cli']` path to the `ember-cli` dependency
-- `{Boolean} [options.disableMocking=false]` turn on the real npm (and bower) to test package installs
+- `{Boolean} [options.disabledTasks=['bower-install', 'npm-install']]` override the mocked installs
   Defaults to [`lib/helpers/tmp-env.js`](lib/helpers/tmp-env.js)
 
 **Returns:** `{Promise}`

--- a/lib/helpers/setup.js
+++ b/lib/helpers/setup.js
@@ -17,12 +17,12 @@ var requireFromCLI = require('./require-from-cli');
   @param {Number} [options.timeout=20000]
   @param {Object} [options.tmpenv]
   @param {String} [options.cliPath='ember-cli'] path to the `ember-cli` dependency
-  @param {Boolean} [options.disableMocking=false] turn on the real npm (and bower) to test
+  @param {Boolean} [options.disabledTasks=['bower-install', 'npm-install']] override the mocked installs
 */
 module.exports = function setupTestHooks(scope, options) {
   var timeout = options && options.timeout || 20000;
   var tmp = options && options.tmpenv || scope.tmpenv || tmpenv;
-  var disableMocking = options && options.disableMocking;
+  var disabledTasks = options && options.disabledTasks || ['bower-install', 'npm-install'];
 
   scope.timeout(timeout);
 
@@ -30,11 +30,11 @@ module.exports = function setupTestHooks(scope, options) {
     requireFromCLI.setBasePath(options.cliPath);
   }
 
-  if (!disableMocking) {
+  if (disabledTasks.length) {
     var Blueprint = requireFromCLI('lib/models/blueprint');
 
     before(function () {
-      MockBlueprintTaskFor.disableTasks(Blueprint, ['npm-install']);
+      MockBlueprintTaskFor.disableTasks(Blueprint, disabledTasks);
     });
 
     after(function() {

--- a/node-tests/blueprints/ember-cli-blueprint-test-helpers-test.js
+++ b/node-tests/blueprints/ember-cli-blueprint-test-helpers-test.js
@@ -55,7 +55,7 @@ describe('Acceptance: ember generate ember-cli-blueprint-test-helpers', function
 
   describe('with mocking', function() {
     setupTestHooks(this, {
-      disableMocking: true,
+      disabledTasks: [],
       timeout: 300000
     });
 


### PR DESCRIPTION
The result of the work of https://github.com/ember-cli/ember-cli-internal-test-helpers/issues/22.

This requires a little scrutiny because it will potentially break people that were depending on a real bower install already. We might need to muddy up the API with an opt-in mocking for bower...

cc @sivakumar-kailasam @Turbo87 @trabus