### PR TITLE
Cleanup symlinked addon after tests

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -7,3 +7,4 @@ chai.use(chaiFiles);
 
 module.exports = chai;
 module.exports.file = chaiFiles.file;
+module.exports.dir = chaiFiles.dir;

--- a/lib/helpers/setup.js
+++ b/lib/helpers/setup.js
@@ -1,12 +1,13 @@
 'use strict';
 
+var path             = require('path');
 var RSVP             = require('rsvp');
 var MockBlueprintTaskFor = require('ember-cli-internal-test-helpers/lib/helpers/mock-blueprint-task-for');
 var fs               = require('fs-extra');
 var remove           = RSVP.denodeify(fs.remove);
 var tmpenv           = require('./tmp-env');
 var debug            = require('debug')('ember-cli:testing');
-var requireFromCLI = require('./require-from-cli');
+var requireFromCLI   = require('./require-from-cli');
 
 /**
   Prepare the test context for the blueprint tests.
@@ -51,6 +52,11 @@ module.exports = function setupTestHooks(scope, options) {
 
   afterEach(function() {
     process.chdir(tmp.root);
-    return remove(tmp.tmproot);
+    return remove(tmp.tmproot)
+      .then(function() {
+        // remove symlinked addon added by emberNew
+        var projectName = require(path.resolve(process.cwd(), 'package.json')).name;
+        return remove(path.join('node_modules', projectName));
+      })
   });
 };

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -3,9 +3,11 @@ var setupTestHooks = require('../../lib/helpers/setup');
 var blueprintHelpers = require('../../helpers');
 var emberNew = blueprintHelpers.emberNew;
 var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var path = require('path');
 
 var chai = require('../../chai');
 var expect = chai.expect;
+var dir = chai.dir;
 
 describe('Acceptance: helpers', function() {
   setupTestHooks(this);
@@ -17,6 +19,21 @@ describe('Acceptance: helpers', function() {
             .to.contain('return emberNew()')
             .to.contain('.then(() => emberGenerateDestroy(args, (file) => {');
         }));
+    });
+  });
+
+  describe('setupTestHooks', function() {
+    var symlink = path.resolve(__dirname, '..', '..', 'node_modules', 'ember-cli-blueprint-test-helpers');
+
+    after(function() {
+      expect(dir(symlink)).to.not.exist;
+    });
+
+    it('cleans up symlinked addon', function() {
+      return emberNew()
+        .then(() => {
+          expect(dir(symlink)).to.exist;
+        });
     });
   });
 });


### PR DESCRIPTION
This PR removes the symlink in `node_modules` left over by `emberNew`.

While this orphaned symlink is probably no big deal for most users other than being a bit awkward, it did have some serious side effects for me. It blew up a following `npm install` with the symlink in place causing some weird recursive installs, probably related to node-sass/node-gyp compilation. See these [logs](https://travis-ci.org/kaliber5/ember-bootstrap/jobs/210707736). And because Travis caches `node_modules`, this skrewed up all test runs (at least after the first uncached run).