### PR TITLE
Make setupPodConfig helper agnostic of variable declaration type

### DIFF
--- a/lib/setup-pod-config.js
+++ b/lib/setup-pod-config.js
@@ -18,6 +18,6 @@ module.exports = function(options) {
 
   // setup environment.js with a pre-set podModulePrefix
   if (options.podModulePrefix) {
-    replaceFile('config/environment.js', 'var ENV = {', 'var ENV = {\npodModulePrefix: \'app/pods\', \n');
+    replaceFile('config/environment.js', '(var|let|const) ENV = {', '$1 ENV = {\npodModulePrefix: \'app/pods\', \n');
   }
 };


### PR DESCRIPTION
The current implementation does not work when using `let` (or `const` for that matters) instead of `var`.