### PR TITLE
Support scoped packages

### DIFF
--- a/lib/ember-new.js
+++ b/lib/ember-new.js
@@ -45,6 +45,11 @@ function linkAddon() {
   var projectName = require(path.resolve(projectPath, 'package.json')).name;
 
   var symlinkPath = path.resolve(projectPath, 'node_modules', projectName);
+  
+  if (!existsSync(path.resolve(symlinkPath, '..'))) {
+    fs.mkdirSync(path.resolve(symlinkPath, '..'));
+  }
+
   if (!existsSync(path.resolve(symlinkPath, 'package.json'))) {
     fs.symlinkSync(projectPath, symlinkPath, 'dir');
   }

--- a/lib/ember-new.js
+++ b/lib/ember-new.js
@@ -45,7 +45,7 @@ function linkAddon() {
   var projectName = require(path.resolve(projectPath, 'package.json')).name;
 
   var symlinkPath = path.resolve(projectPath, 'node_modules', projectName);
-  
+
   if (!existsSync(path.resolve(symlinkPath, '..'))) {
     fs.mkdirSync(path.resolve(symlinkPath, '..'));
   }


### PR DESCRIPTION
Support scoped packages by creating the scope directory under `node_modules`.

resolves #119 