### PR TITLE
use mocha from package.json to keep versions permanently in sync

### DIFF
--- a/blueprints/ember-cli-blueprint-test-helpers/index.js
+++ b/blueprints/ember-cli-blueprint-test-helpers/index.js
@@ -12,8 +12,14 @@ module.exports = {
 
     return Promise.all([
       this.insertIntoFile('./.npmignore', '/node-tests' + EOL),
-      this.addPackagesToProject([{name: 'mocha', target: '^3.5.3'}]),
+      this.addMochaToPackage(),
     ]);
+  },
+
+  addMochaToPackage: function() {
+    var pkg = fs.readJsonSync(path.join(__dirname, '../../package.json'));
+
+    return this.addPackageToProject('mocha', pkg.devDependencies['mocha']);
   },
 
   insertTestCallToPackage: function() {


### PR DESCRIPTION
Copied from https://github.com/kellyselden/ember-datetimepicker/pull/152. Seems like a good idea since package.json is there in node_modules when installed.