### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 
-- `{Boolean} [options.isModuleUnification=true]` a toggle to use MU file structure 
 ember-cli-blueprint-test-helpers
 ==============================================================================
 


### PR DESCRIPTION
Fix a small typo in README (introduced in https://github.com/ember-cli/ember-cli-blueprint-test-helpers/pull/153)