### PR TITLE
Adjust `.npmignore` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,9 @@
-blueprint-nodetest.js
+/node-tests/
+/tests/
+/.editorconfig
+/.eslintignore
+/.eslintrc.js
+/.github_changelog_generator
+/.travis.yml
+/appveyor.yml
+/yarn.lock


### PR DESCRIPTION
to get rid of unnecessary weight (primarily `yarn.lock`)