### PR TITLE
Fix Docs and modernize test

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ which will generate a test file at `node-tests/blueprints/my-blueprint-test.js`.
 ### Example Usage
 
 ```js
+const { 
+  setupTestHooks,
+  emberNew,
+  emberGenerateDestroy,
+} = require('ember-cli-blueprint-test-helpers/helpers');
+
+const {
+  expect
+} = require('ember-cli-blueprint-test-helpers/chai');
+
 describe('Acceptance: ember generate and destroy my-blueprint', function() {
   // create and destroy temporary working directories
   setupTestHooks(this);
@@ -82,6 +92,18 @@ describe('Acceptance: ember generate and destroy my-blueprint', function() {
 or more explicitly:
 
 ```js
+const { 
+  setupTestHooks,
+  emberNew,
+  emberGenerate,
+  emberDestroy,
+} = require('ember-cli-blueprint-test-helpers/helpers');
+
+const {
+  expect,
+  file,
+} = require('ember-cli-blueprint-test-helpers/chai');
+
 describe('Acceptance: ember generate and destroy my-blueprint', function() {
   // create and destroy temporary working directories
   setupTestHooks(this);
@@ -114,6 +136,18 @@ if your blueprints support the new
 using this option: `{ ìsModuleUnification: true }`
 
 ```js
+const { 
+  setupTestHooks,
+  emberNew,
+  emberGenerate,
+  emberDestroy,
+} = require('ember-cli-blueprint-test-helpers/helpers');
+
+const {
+  expect,
+  file,
+} = require('ember-cli-blueprint-test-helpers/chai');
+
 describe('Acceptance: ember generate and destroy my-blueprint', function() {
   // create and destroy temporary working directories
   setupTestHooks(this);

--- a/blueprints/blueprint-test/files/__root__/__name__-test.js
+++ b/blueprints/blueprint-test/files/__root__/__name__-test.js
@@ -1,21 +1,24 @@
 'use strict';
 
-const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
-const setupTestHooks = blueprintHelpers.setupTestHooks;
-const emberNew = blueprintHelpers.emberNew;
-const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+const { 
+  setupTestHooks,
+  emberNew,
+  emberGenerateDestroy,
+} = require('ember-cli-blueprint-test-helpers/helpers');
 
-const expect = require('ember-cli-blueprint-test-helpers/chai').expect;
+const {
+  expect
+} = require('ember-cli-blueprint-test-helpers/chai');
 
 describe('Acceptance: ember generate and destroy <%= blueprintName %>', function() {
   setupTestHooks(this);
 
   it('<%= blueprintName %> foo', function() {
-    let args = ['<%= blueprintName %>', 'foo'];
+    const args = ['<%= blueprintName %>', 'foo'];
 
     // pass any additional command line options in the arguments array
     return emberNew(<%= muOption %>)
-      .then(() => emberGenerateDestroy(args, (file) => {
+      .then(() => emberGenerateDestroy(args, () => {
         // expect(file('app/type/foo.js')).to.contain('foo');
     }));
   });

--- a/blueprints/blueprint-test/files/__root__/__name__-test.js
+++ b/blueprints/blueprint-test/files/__root__/__name__-test.js
@@ -14,11 +14,11 @@ describe('Acceptance: ember generate and destroy <%= blueprintName %>', function
   setupTestHooks(this);
 
   it('<%= blueprintName %> foo', function() {
-    const args = ['<%= blueprintName %>', 'foo'];
+    let args = ['<%= blueprintName %>', 'foo'];
 
     // pass any additional command line options in the arguments array
     return emberNew(<%= muOption %>)
-      .then(() => emberGenerateDestroy(args, () => {
+      .then(() => emberGenerateDestroy(args, (/* file */) => {
         // expect(file('app/type/foo.js')).to.contain('foo');
     }));
   });


### PR DESCRIPTION
This is a small PR just to update the test boilerplate to node >=6 syntax with the destructuring requires.  Also, I wanted to update the documentation since I was a bit lost since the examples did not have the "require" modules that included chai's "file" method that was needed when using "emberGenerate" and "emberDestroy".