### PR TITLE
Remove "Module Unification" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,51 +131,6 @@ describe('Acceptance: ember generate and destroy my-blueprint', function() {
 });
 ```
 
-if your blueprints support the new
-[MU file structure](https://github.com/emberjs/rfcs/pull/143), you can test them
-using this option: `{ ìsModuleUnification: true }`
-
-```js
-const { 
-  setupTestHooks,
-  emberNew,
-  emberGenerate,
-  emberDestroy,
-} = require('ember-cli-blueprint-test-helpers/helpers');
-
-const {
-  expect,
-  file,
-} = require('ember-cli-blueprint-test-helpers/chai');
-
-describe('Acceptance: ember generate and destroy my-blueprint', function() {
-  // create and destroy temporary working directories
-  setupTestHooks(this);
-
-  it('my-blueprint foo', function() {
-    const args = ['my-blueprint', 'foo'];
-
-    // create a new Ember.js app in the working directory
-    // this app will have MU file structure, namely a `src` directory
-    return emberNew({ isModuleUnification: true })
-
-      // then generate the `my-blueprint` blueprint called `foo`
-      .then(() => emberGenerate(args, { isModuleUnification: true }))
-
-      // then assert that the files were generated correctly
-      .then(() => expect(file('path/to/file.js'))
-        .to.contain('file contents to match')
-        .to.contain('more file contents\n'))
-
-      // then destroy the `my-blueprint` blueprint called `foo`
-      .then(() => emberDestroy(args, { isModuleUnification: true }))
-
-      // then assert that the files were destroyed correctly
-      .then(() => expect(file('path/to/file.js')).to.not.exist);
-  });
-});
-```
-
 API Reference
 ------------------------------------------------------------------------------
 
@@ -219,41 +174,36 @@ Create a new Ember.js app or addon in the current working directory.
 
 - `{Object} [options]` optional parameters
 - `{String} [options.target='app']` the type of project to create (`app`, `addon` or `in-repo-addon`)
-- `{Boolean} [options.isModuleUnification=true]` a toggle to use MU file structure 
 
 **Returns:** `{Promise}`
 
 ---
 
-### `emberGenerate(args, options)`
+### `emberGenerate(args)`
 
 Run a blueprint generator.
 
 **Parameters:**
 
 - `{Array.<String>} args` arguments to pass to `ember generate` (e.g. `['my-blueprint', 'foo']`)
-- `{Object} [options]` optional parameters
-- `{Boolean} [options.isModuleUnification=true]` a toggle to use MU file structure 
 
 **Returns:** `{Promise}`
 
 ---
 
-### `emberDestroy(args, options)`
+### `emberDestroy(args)`
 
 Run a blueprint destructor.
 
 **Parameters:**
 
 - `{Array.<String>} args` arguments to pass to `ember destroy` (e.g. `['my-blueprint', 'foo']`)
-- `{Object} [options]` optional parameters
-- `{Boolean} [options.isModuleUnification=true]` a toggle to use MU file structure 
 
 **Returns:** `{Promise}`
 
 ---
 
-### `emberGenerateDestroy(args, assertionCallback, options)`
+### `emberGenerateDestroy(args, assertionCallback)`
 
 Run a blueprint generator and the corresponding blueprint destructor while
 checking assertions in between.
@@ -262,8 +212,6 @@ checking assertions in between.
 
 - `{Array.<String>} args` arguments to pass to `ember generate` (e.g. `['my-blueprint', 'foo']`)
 - `{Function} assertionCallback` the callback function in which the assertions should happen
-- `{Object} [options]` optional parameters
-- `{Boolean} [options.isModuleUnification=true]` a toggle to use MU file structure 
 
 **Returns:** `{Promise}`
 

--- a/blueprints/blueprint-test/files/__root__/__name__-test.js
+++ b/blueprints/blueprint-test/files/__root__/__name__-test.js
@@ -17,7 +17,7 @@ describe('Acceptance: ember generate and destroy <%= blueprintName %>', function
     let args = ['<%= blueprintName %>', 'foo'];
 
     // pass any additional command line options in the arguments array
-    return emberNew(<%= muOption %>)
+    return emberNew()
       .then(() => emberGenerateDestroy(args, (/* file */) => {
         // expect(file('app/type/foo.js')).to.contain('foo');
     }));

--- a/blueprints/blueprint-test/index.js
+++ b/blueprints/blueprint-test/index.js
@@ -14,11 +14,6 @@ module.exports = {
 
   locals(options) {
     const blueprintName = options.entity.name;
-    const muOption =
-      (options.project.isModuleUnification())
-        ? '{ isModuleUnification: true }'
-        : null;
-
-    return { blueprintName, muOption };
+    return { blueprintName };
   }
 }

--- a/lib/ember-destroy.js
+++ b/lib/ember-destroy.js
@@ -2,10 +2,6 @@
 
 const ember = require('./helpers/ember');
 const rethrowFromErrorLog = require('./rethrow-from-error-log');
-const {
-  enableModuleUnification,
-  disableModuleUnification
-} = require('./helpers/module-unification-experiment');
 
 /**
  * Run a blueprint destructor.
@@ -13,18 +9,13 @@ const {
  * @param {Array.<String>} args arguments to pass to `ember destroy` (e.g. `['my-blueprint', 'foo']`)
  * @returns {Promise}
  */
-module.exports = function(args, options) {
-  options = options || {};
-
+module.exports = function(args) {
   let commandArgs = ['destroy'].concat(args);
 
   let cliOptions = {
     disableDependencyChecker: true,
   };
 
-  let originalENV = enableModuleUnification(options.isModuleUnification);
-
   return ember(commandArgs, cliOptions)
-    .catch(rethrowFromErrorLog)
-    .finally(() => disableModuleUnification(originalENV));
+    .catch(rethrowFromErrorLog);
 };

--- a/lib/ember-generate.js
+++ b/lib/ember-generate.js
@@ -2,10 +2,6 @@
 
 const ember = require('./helpers/ember');
 const rethrowFromErrorLog = require('./rethrow-from-error-log');
-const {
-  enableModuleUnification,
-  disableModuleUnification
-} = require('./helpers/module-unification-experiment');
 
 /**
  * Run a blueprint generator.
@@ -13,18 +9,13 @@ const {
  * @param {Array.<String>} args arguments to pass to `ember generate` (e.g. `['my-blueprint', 'foo']`)
  * @returns {Promise}
  */
-module.exports = function(args, options) {
-  options = options || {};
-
+module.exports = function(args) {
   let commandArgs = ['generate'].concat(args);
 
   let cliOptions = {
     disableDependencyChecker: true
   };
 
-  let originalENV = enableModuleUnification(options.isModuleUnification);
-
   return ember(commandArgs, cliOptions)
-    .catch(rethrowFromErrorLog)
-    .finally(() => disableModuleUnification(originalENV));
+    .catch(rethrowFromErrorLog);
 };

--- a/lib/ember-new.js
+++ b/lib/ember-new.js
@@ -6,10 +6,6 @@ const path = require('path');
 const ember = require('./helpers/ember');
 const modifyPackages = require('./modify-packages');
 const rethrowFromErrorLog = require('./rethrow-from-error-log');
-const {
-  enableModuleUnification,
-  disableModuleUnification
-} = require('./helpers/module-unification-experiment');
 
 /**
  * Create a new Ember.js app or addon in the current working directory.
@@ -31,13 +27,10 @@ module.exports = function(options) {
     disableDependencyChecker: true
   };
 
-  let originalENV = enableModuleUnification(options.isModuleUnification);
-
   return ember([command, projectName, '--skip-npm', '--skip-bower'], cliOptions)
     .then(generateInRepoAddon(target))
     .then(linkAddon)
-    .catch(rethrowFromErrorLog)
-    .finally(() => disableModuleUnification(originalENV));
+    .catch(rethrowFromErrorLog);
 };
 
 function generateInRepoAddon(target) {

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -33,17 +33,6 @@ describe('Acceptance: helpers', function() {
           expect(fs.existsSync(addonPath)).to.equal(true);
         });
     });
-
-    it('emberNew - MU app', () => {
-      return emberNew({ isModuleUnification: true })
-        .then(() => {
-          const srcPath = path.resolve(process.cwd(), 'src');
-          expect(fs.existsSync(srcPath)).to.equal(true);
-        })
-        .then(() => {
-          expect(process.env["EMBER_CLI_MODULE_UNIFICATION"]).to.equal(undefined);
-        });
-    });
   });
 
   describe('emberGenerateDestroy', () => {
@@ -53,25 +42,6 @@ describe('Acceptance: helpers', function() {
           expect(file('node-tests/blueprints/foo-test.js'))
             .to.contain('return emberNew()');
         }));
-    });
-
-    it('blueprint-test foo - in a MU app with no flag', () => {
-      return emberNew({ isModuleUnification: true })
-        .then(() => emberGenerateDestroy(['blueprint-test', 'foo'], (file) => {
-          expect(file('node-tests/blueprints/foo-test.js'))
-            .to.contain('return emberNew()');
-        }));
-    });
-
-    it('blueprint-test foo - in a MU app with MU flag', () => {
-      return emberNew({ isModuleUnification: true })
-        .then(() => emberGenerateDestroy(['blueprint-test', 'foo'], (file) => {
-          expect(file('node-tests/blueprints/foo-test.js'))
-            .to.contain('return emberNew({ isModuleUnification: true })');
-        }, { isModuleUnification: true }))
-        .then(() => {
-          expect(process.env["EMBER_CLI_MODULE_UNIFICATION"]).to.equal(undefined);
-        });
     });
   });
 
@@ -88,23 +58,6 @@ describe('Acceptance: helpers', function() {
         .then(() => emberDestroy(args))
         .then(() => {
           expect(file('node-tests/blueprints/foo-test.js')).to.not.exist;
-        });
-    });
-
-    it('blueprint-test foo - in a MU app', () => {
-      const args = ['blueprint-test', 'foo'];
-
-      return emberNew({ isModuleUnification: true })
-        .then(() => emberGenerate(args, { isModuleUnification: true }))
-        .then(() => {
-          expect(file('node-tests/blueprints/foo-test.js'))
-            .to.contain('return emberNew({ isModuleUnification: true })');
-        })
-        .then(() => emberDestroy(args, { isModuleUnification: true }))
-        .then(() => {
-          expect(file('node-tests/blueprints/foo-test.js')).to.not.exist;
-
-          expect(process.env["EMBER_CLI_MODULE_UNIFICATION"]).to.equal(undefined);
         });
     });
   });


### PR DESCRIPTION
Since Ember CLI no longer supports it either...

This will unblock any further PRs since our CI here does not use yarn and so it also does not use a lockfile for Ember CLI 😱 