### PR TITLE
Add an `extraCliArgs` option to the `emberNew` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Create a new Ember.js app or addon in the current working directory.
 
 - `{Object} [options]` optional parameters
 - `{String} [options.target='app']` the type of project to create (`app`, `addon` or `in-repo-addon`)
+- `{string[]} [options.extraCliArgs=[]]` any extra arguments you want to pass to ember-cli
 
 **Returns:** `{Promise}`
 

--- a/lib/ember-new.js
+++ b/lib/ember-new.js
@@ -12,6 +12,7 @@ const rethrowFromErrorLog = require('./rethrow-from-error-log');
  *
  * @param {Object} [options] optional parameters
  * @param {String} [options.target='app'] the type of project to create (`app`, `addon` or `in-repo-addon`)
+ * @param {string[]} [options.extraCliArgs] any extra arguments you want to pass to ember-cli
  * @returns {Promise}
  */
 module.exports = function(options) {
@@ -22,12 +23,13 @@ module.exports = function(options) {
 
   let projectName = isAddon ? 'my-addon' : 'my-app';
   let command = isAddon ? 'addon' : 'new';
+  let extraCliArgs = Array.isArray(options.extraCliArgs) ? options.extraCliArgs : [];
 
   let cliOptions = {
     disableDependencyChecker: true
   };
 
-  return ember([command, projectName, '--skip-npm', '--skip-bower'], cliOptions)
+  return ember([command, projectName, '--skip-npm', '--skip-bower', ...extraCliArgs], cliOptions)
     .then(generateInRepoAddon(target))
     .then(linkAddon)
     .catch(rethrowFromErrorLog);

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -14,7 +14,7 @@ const expect = chai.expect;
 const dir = chai.dir;
 const file = chai.file;
 
-describe('Acceptance: helpers', function() {
+describe('Acceptance: helpers', function () {
   setupTestHooks(this);
 
   describe('emberNew', () => {
@@ -31,6 +31,14 @@ describe('Acceptance: helpers', function() {
         .then(() => {
           const addonPath = path.resolve(process.cwd(), 'addon');
           expect(fs.existsSync(addonPath)).to.equal(true);
+        });
+    });
+
+    it('emberNew - extraCliArgs', () => {
+      return emberNew({ extraCliArgs: ['--typescript', '--no-welcome']})
+        .then(() => {
+          const appPath = path.resolve(process.cwd(), 'app');
+          expect(fs.existsSync(appPath)).to.equal(true);
         });
     });
   });

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -33,14 +33,6 @@ describe('Acceptance: helpers', function () {
           expect(fs.existsSync(addonPath)).to.equal(true);
         });
     });
-
-    it('emberNew - extraCliArgs', () => {
-      return emberNew({ extraCliArgs: ['--typescript', '--no-welcome']})
-        .then(() => {
-          const appPath = path.resolve(process.cwd(), 'app');
-          expect(fs.existsSync(appPath)).to.equal(true);
-        });
-    });
   });
 
   describe('emberGenerateDestroy', () => {

--- a/tests/unit/ember-new-test.js
+++ b/tests/unit/ember-new-test.js
@@ -1,0 +1,38 @@
+'use strict';
+const setupTestHooks = require('../../lib/helpers/setup');
+
+const chai = require('../../chai');
+const expect = chai.expect;
+const td = require('testdouble')
+
+let ember;
+
+describe('Unit: emberNew', function () {
+  setupTestHooks(this);
+
+  afterEach(() => {
+    td.reset();
+    ember = undefined;
+  });
+
+  it('emberNew - extraCliArgs', () => {
+    const originalEmber = require('../../lib/helpers/ember.js');
+    ember = td.replace('../../lib/helpers/ember.js');
+
+    // "spy" on the original ember function.
+    // testdouble.js doesn't have built-in support for this because it considers it a bad practise:
+    // https://github.com/testdouble/testdouble.js/issues/512#issuecomment-1527511338
+    td.when(ember(td.matchers.contains('--typescript', '--no-welcome'), td.matchers.anything())).thenDo((...args) => {
+      return originalEmber(...args);
+    });
+
+    // We require emberNew here so the testdouble dependency replacement works
+    const emberNew = require('../../lib/ember-new');
+
+    return emberNew({ extraCliArgs: ['--typescript', '--no-welcome'] })
+      .then(() => {
+        // If we get here that means our testdouble matcher worked and things were called as expected.
+        expect(true).to.be.true;
+      });
+  });
+});


### PR DESCRIPTION
This makes it possible to pass any extra arguments to ember-cli.

Closes #391 and unblocks https://github.com/emberjs/ember.js/pull/20771